### PR TITLE
Profile audio: check some values when setProfile

### DIFF
--- a/src/AvTranscoder/EssenceStream/OutputAudio.cpp
+++ b/src/AvTranscoder/EssenceStream/OutputAudio.cpp
@@ -174,10 +174,21 @@ void OutputAudio::setProfile( Profile::ProfileDesc& desc, const AudioFrameDesc& 
 	if( ! desc.count( Profile::avProfileCodec ) || 		
 		! desc.count( Profile::avProfileSampleFormat ) || 
 		! desc.count( Profile::avProfileSampleRate ) || 
-		! desc.count( Profile::avProfileChannel ) )
+		! desc.count( Profile::avProfileChannel ) || 
+		! desc.count( Profile::avProfileChannelLayout ) )
 	{
 		throw std::runtime_error( "The profile " + desc[ Profile::avProfileIdentificatorHuman ] + " is invalid." );
 	}
+	
+	// check some values of the profile
+	if( desc[ Profile::avProfileSampleRate ] == "0" )
+		throw std::runtime_error( "Profile " + desc[ Profile::avProfileIdentificatorHuman ] + ": bad sample rate." );
+	
+	if( desc[ Profile::avProfileChannel ] == "0" )
+		throw std::runtime_error( "Profile " + desc[ Profile::avProfileIdentificatorHuman ] + ": bad audio channel." );
+	
+	if( desc[ Profile::avProfileChannelLayout ] == "0" )
+		throw std::runtime_error( "Profile " + desc[ Profile::avProfileIdentificatorHuman ] + ": bad audio channel layout." );
 	
 	_audioDesc.setAudioCodec( desc[ Profile::avProfileCodec ] );
 	size_t sample_rate = std::strtoul( desc[ Profile::avProfileSampleRate ].c_str(), NULL, 0 );

--- a/src/AvTranscoder/Profile.cpp
+++ b/src/AvTranscoder/Profile.cpp
@@ -24,7 +24,8 @@ const std::string Profile::avProfilePixelFormat( "pix_fmt" );
 const std::string Profile::avProfileSampleFormat( "sample_fmt" );
 const std::string Profile::avProfileFrameRate( "r" );
 const std::string Profile::avProfileSampleRate( "ar" );
-const std::string Profile::avProfileChannel( "channel" );
+const std::string Profile::avProfileChannel( "ac" );
+const std::string Profile::avProfileChannelLayout( "channel_layout" );
 const std::string Profile::avProfileWidth( "width" );
 const std::string Profile::avProfileHeight( "height" );
 

--- a/src/AvTranscoder/Profile.hpp
+++ b/src/AvTranscoder/Profile.hpp
@@ -25,6 +25,7 @@ public:
 	static const std::string avProfileFrameRate;
 	static const std::string avProfileSampleRate;
 	static const std::string avProfileChannel;
+	static const std::string avProfileChannelLayout;
 	
 	static const std::string avProfileWidth;
 	static const std::string avProfileHeight;

--- a/src/AvTranscoder/Profiles/Wave.hpp
+++ b/src/AvTranscoder/Profiles/Wave.hpp
@@ -16,6 +16,7 @@ void loadWave( Profile::ProfilesDesc& profiles )
 	wave24b48kMono[ Profile::avProfileSampleFormat ] = "s32";
 	wave24b48kMono[ Profile::avProfileSampleRate ] = "48000";
 	wave24b48kMono[ Profile::avProfileChannel ] = "1";
+	wave24b48kMono[ Profile::avProfileChannelLayout ] = "1";
 
 	Profile::ProfileDesc wave16b48kMono;
 
@@ -27,6 +28,7 @@ void loadWave( Profile::ProfilesDesc& profiles )
 	wave16b48kMono[ Profile::avProfileSampleFormat ] = "s16";
 	wave16b48kMono[ Profile::avProfileSampleRate ] = "48000";
 	wave16b48kMono[ Profile::avProfileChannel ] = "1";
+	wave16b48kMono[ Profile::avProfileChannelLayout ] = "1";
 
 	profiles.push_back( wave24b48kMono );
 	profiles.push_back( wave16b48kMono );


### PR DESCRIPTION
- When set profile of OutputAudio, check:
  - sample rate value.
  - audio channel value.
  - audio channel layout value.
- Update Wave profiles: add ChannelLayout.
