### PR TITLE
Transcoder: can process transcode with only dummy

### DIFF
--- a/src/AvTranscoder/Transcoder/Transcoder.hpp
+++ b/src/AvTranscoder/Transcoder/Transcoder.hpp
@@ -126,6 +126,8 @@ private:
 
 	Profile _profile;
 
+	double _outputFps;
+
 	size_t _finalisedStreams;
 	EProcessMethod _eProcessMethod;
 


### PR DESCRIPTION
- Add attribute _outputFps.
- In process method, get totalDuration depending on the process method.
