### PR TITLE
DummyVideo: get a black image

### DIFF
--- a/src/AvTranscoder/EssenceStream/DummyVideo.cpp
+++ b/src/AvTranscoder/EssenceStream/DummyVideo.cpp
@@ -1,5 +1,7 @@
 #include "DummyVideo.hpp"
 
+#include <AvTranscoder/EssenceTransform/VideoEssenceTransform.hpp>
+
 namespace avtranscoder
 {
 
@@ -36,11 +38,25 @@ bool DummyVideo::readNextFrame( Frame& frameBuffer )
 {
 	if( ! _inputFrame )
 	{
-		int fillChar = 0; // fill images with black
-		
+		// @todo support PAL (0 to 255) and NTFC (16 to 235)
+		int fillChar = 0;
+
 		if( frameBuffer.getSize() != _videoFrameDesc.getDataSize() )
 			frameBuffer.getBuffer().resize( _videoFrameDesc.getDataSize() );
-		memset( frameBuffer.getPtr(), fillChar, _videoFrameDesc.getDataSize() );
+
+		VideoFrameDesc desc( _videoDesc.getVideoFrameDesc() );
+		Pixel rgbPixel;
+		rgbPixel.setColorComponents( eComponentRgb );
+		rgbPixel.setPlanar( false );
+		desc.setPixel( rgbPixel );
+
+		VideoFrame intermediateBuffer( desc );
+		intermediateBuffer.getBuffer().resize( _videoFrameDesc.getDataSize() );
+		memset( intermediateBuffer.getPtr(), fillChar, _videoFrameDesc.getDataSize() );
+
+		VideoEssenceTransform videoEssenceTransform;
+		videoEssenceTransform.convert( intermediateBuffer, frameBuffer );
+
 		return true;
 	}
 	


### PR DESCRIPTION
- Get a black image as dummy video, whatever the pixel format.
- Use the color conversion at each new frame.
