### PR TITLE
StreamTranscoder: fix when transcode dummy audio stream

### DIFF
--- a/src/AvTranscoder/Transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/Transcoder/StreamTranscoder.cpp
@@ -225,7 +225,7 @@ StreamTranscoder::StreamTranscoder(
 
 		_transform = new AudioEssenceTransform();
 		
-		_currentEssence = _dummyEssence;
+		_currentEssence = _inputEssence;
 		return;
 	}
 


### PR DESCRIPTION
- Concern the StreamTranscoder's constructor for dummy.
- In this case, _dummyEssence is NULL: get the dummy stream from
  _inputEssence.
