### PR TITLE
common: replace Rational typedef to a new class

### DIFF
--- a/src/AvTranscoder/common.hpp
+++ b/src/AvTranscoder/common.hpp
@@ -12,6 +12,7 @@ extern "C" {
 #include <libavformat/version.h>
 #include <libavcodec/version.h>
 #include <libavcodec/avcodec.h>
+#include <libavutil/rational.h>
 }
 
 #include <string>
@@ -53,7 +54,34 @@ namespace avtranscoder
 
 #define MAX_SWS_PLANE 4
 
-typedef AVRational Rational;
+/**
+ * @brief Wrapper of AVRational.
+ */
+class Rational
+{
+public:
+	Rational()
+	{
+		_ratio.num = 0;
+		_ratio.den = 0;
+	}
+
+	Rational( const int num, const int den )
+	{
+		_ratio.num = num;
+		_ratio.den = den;
+	}
+
+	double getRatio() const { return _ratio.num / _ratio.den; }
+	int getNum() const { return _ratio.num; }
+	int getDen() const { return _ratio.den; }
+	AVRational& getAVRational() { return _ratio; }
+
+	int setNum( int num ) { _ratio.num = num; }
+	int setDen( int den ) { _ratio.den = den; }
+private:
+	AVRational _ratio;
+};
 
 #ifndef SWIG
 void split( std::vector< std::string >& splitedString, const std::string& inputString, const std::string& splitChars = ";" );

--- a/src/AvTranscoder/frame/VideoFrame.hpp
+++ b/src/AvTranscoder/frame/VideoFrame.hpp
@@ -30,18 +30,16 @@ public:
 	VideoFrameDesc()
 		: _width( 0 )
 		, _height( 0 )
+		, _displayAspectRatio()
 		, _pixel()
 		, _interlaced( false )
 		, _topFieldFirst( false )
-	{
-		_displayAspectRatio.num = 0;
-		_displayAspectRatio.den = 0;
-	}
+	{}
 	
 	void setWidth ( const size_t width     ) { _width = width; }
 	void setHeight( const size_t height    ) { _height = height; }
 	void setPixel ( const Pixel  pixel     ) { _pixel = pixel; }
-	void setDar( const size_t num, const size_t den ) { _displayAspectRatio.num = num; _displayAspectRatio.den = den; }
+	void setDar( const size_t num, const size_t den ) { _displayAspectRatio = Rational( num, den); }
 	void setDar( const Rational ratio ) { _displayAspectRatio = ratio; }
 	
 	void setParameters( const Profile::ProfileDesc& desc )
@@ -53,8 +51,6 @@ public:
 	size_t               getWidth ()    const { return _width;  }
 	size_t               getHeight()    const { return _height; }
 	Rational getDar() const { return _displayAspectRatio; }
-	int getDarNum() const { return _displayAspectRatio.num; }
-	int getDarDen() const { return _displayAspectRatio.den; }
 	Pixel                getPixelDesc() const { return _pixel; }
 
 	size_t getDataSize() const
@@ -75,7 +71,7 @@ public:
 private:
 	size_t          _width;
 	size_t          _height;
-	Rational      _displayAspectRatio;
+	Rational        _displayAspectRatio;
 	Pixel           _pixel;
 	// ColorProperties _color;
 

--- a/src/AvTranscoder/mediaProperty/VideoStreamProperty.hpp
+++ b/src/AvTranscoder/mediaProperty/VideoStreamProperty.hpp
@@ -132,10 +132,10 @@ VideoProperties videoStreamInfo(
 	vp.profile          = codec_context->profile,
 	vp.level            = codec_context->level;
 
-	vp.timeBase.num     = codec_context->time_base.num;
-	vp.timeBase.den     = codec_context->time_base.den;
-	vp.sar.num          = codec_context->sample_aspect_ratio.num;
-	vp.sar.den          = codec_context->sample_aspect_ratio.den;
+	vp.timeBase.setNum( codec_context->time_base.num );
+	vp.timeBase.setDen( codec_context->time_base.den );
+	vp.sar.setNum( codec_context->sample_aspect_ratio.num );
+	vp.sar.setDen( codec_context->sample_aspect_ratio.den );
 	
 	vp.startTimecode    = makeTimecodeMpegToString( codec_context->timecode_frame_start );
 
@@ -144,8 +144,8 @@ VideoProperties videoStreamInfo(
 			   codec_context->width * codec_context->sample_aspect_ratio.num,
 			   codec_context->height * codec_context->sample_aspect_ratio.den,
 			   1024 * 1024);
-	vp.dar.num = darNum;
-	vp.dar.den = darDen;
+	vp.dar.setNum( darNum );
+	vp.dar.setDen( darDen );
 
 	vp.fps = 1.0 * codec_context->time_base.den / ( codec_context->time_base.num * codec_context->ticks_per_frame );
 	

--- a/src/AvTranscoder/mediaProperty/mediaProperty.cpp
+++ b/src/AvTranscoder/mediaProperty/mediaProperty.cpp
@@ -58,8 +58,8 @@ MetadatasMap VideoProperties::getDataMap() const
 	detail::add( dataMap, "start timecode", startTimecode );
 	detail::add( dataMap, "width", width );
 	detail::add( dataMap, "height", height );
-	detail::add( dataMap, "pixel aspect ratio", sar.num / sar.den );
-	detail::add( dataMap, "display aspect ratio", dar.num / dar.den );
+	detail::add( dataMap, "pixel aspect ratio", sar.getRatio() );
+	detail::add( dataMap, "display aspect ratio", dar.getRatio() );
 	detail::add( dataMap, "dtgActiveFormat", dtgActiveFormat );
 	detail::add( dataMap, "components count", componentsCount );
 	detail::add( dataMap, "pixel type", pixelName );
@@ -79,7 +79,7 @@ MetadatasMap VideoProperties::getDataMap() const
 	detail::add( dataMap, "interlaced ", isInterlaced );
 	detail::add( dataMap, "top field first", topFieldFirst );
 	detail::add( dataMap, "field order", fieldOrder);
-	detail::add( dataMap, "timeBase", timeBase.num / timeBase.den );
+	detail::add( dataMap, "timeBase", timeBase.getRatio() );
 	detail::add( dataMap, "fps", fps );
 	detail::add( dataMap, "ticksPerFrame", ticksPerFrame );
 	detail::add( dataMap, "bit rate", bitRate );

--- a/src/AvTranscoder/mediaProperty/mediaProperty.hpp
+++ b/src/AvTranscoder/mediaProperty/mediaProperty.hpp
@@ -3,10 +3,6 @@
 
 #include <AvTranscoder/common.hpp>
 
-extern "C" {
-#include <libavutil/rational.h>
-}
-
 #include <string>
 #include <vector>
 #include <map>
@@ -36,17 +32,6 @@ struct AvExport Channel
 
 struct AvExport VideoProperties
 {
-	VideoProperties()
-	{
-		timeBase.num = 0;
-		timeBase.den = 0;
-		sar.num = 0;
-		sar.den = 0;
-		dar.num = 0;
-		dar.den = 0;
-	}
-	
-public:
 	std::string codecName;
 	std::string codecLongName;
 	std::string profileName;

--- a/src/AvTranscoder/option/Option.cpp
+++ b/src/AvTranscoder/option/Option.cpp
@@ -142,10 +142,8 @@ void Option::setInt( const int value )
 
 void Option::setRatio( const int num, const int den )
 {
-	Rational ratio;
-	ratio.num = num;
-	ratio.den = den;
-	int error = av_opt_set_q( _avContext, getName().c_str(), ratio, AV_OPT_SEARCH_CHILDREN );
+	Rational ratio( num, den );
+	int error = av_opt_set_q( _avContext, getName().c_str(), ratio.getAVRational(), AV_OPT_SEARCH_CHILDREN );
 	if( error )
 	{
 		std::ostringstream os;

--- a/test/pyTest/testTranscoderRewrap.py
+++ b/test/pyTest/testTranscoderRewrap.py
@@ -110,12 +110,12 @@ def testRewrapVideoStream():
 	assert_equals( src_videoStream.endianess, dst_videoStream.endianess )
 	assert_equals( src_videoStream.startTimecode, dst_videoStream.startTimecode )
 
-	#assert_equals( src_videoStream.timeBase.num, dst_videoStream.timeBase.num )
-	#assert_equals( src_videoStream.timeBase.den, dst_videoStream.timeBase.den )
-	#assert_equals( src_videoStream.sar.num, dst_videoStream.sar.num )
-	#assert_equals( src_videoStream.sar.den, dst_videoStream.sar.den )
-	#assert_equals( src_videoStream.dar.num, dst_videoStream.dar.num )
-	#assert_equals( src_videoStream.dar.den, dst_videoStream.dar.den )
+	assert_equals( src_videoStream.timeBase.getNum(), dst_videoStream.timeBase.getNum() )
+	assert_equals( src_videoStream.timeBase.getDen(), dst_videoStream.timeBase.getDen() )
+	assert_equals( src_videoStream.sar.getNum(), dst_videoStream.sar.getNum() )
+	assert_equals( src_videoStream.sar.getDen(), dst_videoStream.sar.getDen() )
+	assert_equals( src_videoStream.dar.getNum(), dst_videoStream.dar.getNum() )
+	assert_equals( src_videoStream.dar.getDen(), dst_videoStream.dar.getDen() )
 	
 	assert_equals( src_videoStream.streamId, dst_videoStream.streamId )
 	assert_equals( src_videoStream.codecId, dst_videoStream.codecId )


### PR DESCRIPTION
- Issue in bindings with a typedef of a class defined by FFmpeg.
- Solution: create a class which is a wrapper of AVRational.
- Update pyTest which use Rational.
