### PR TITLE
Profile: rename to ProfileLoader

### DIFF
--- a/app/avTranscoder/avTranscoder.cpp
+++ b/app/avTranscoder/avTranscoder.cpp
@@ -22,7 +22,7 @@ void transcodeVideo( const char* inputfilename, const char* outputFilename )
 
 	// av_log_set_level( AV_LOG_DEBUG );
 
-	Profile profile( true );
+	ProfileLoader profileLoader( true );
 	ConsoleProgress p;
 
 	InputFile input( inputfilename );
@@ -37,7 +37,7 @@ void transcodeVideo( const char* inputfilename, const char* outputFilename )
 
 	// init video encoder
 	AvOutputVideo outputVideo;
-	outputVideo.setProfile( profile.getProfile( "xdcamhd422" ), VideoFrameDesc );
+	outputVideo.setProfile( profileLoader.getProfile( "xdcamhd422" ), VideoFrameDesc );
 	VideoFrame imageToEncode( outputVideo.getVideoCodec().getVideoFrameDesc() );
 	
 	CodedData codedImage;

--- a/app/genericProcessor/genericProcessor.cpp
+++ b/app/genericProcessor/genericProcessor.cpp
@@ -17,7 +17,7 @@ static const std::string dummyAudioCodec = "pcm_s16le";
 
 bool verbose = false;
 
-void parseConfigFile( const std::string& configFilename, avtranscoder::Transcoder& transcoder, avtranscoder::Profile& profile )
+void parseConfigFile( const std::string& configFilename, avtranscoder::Transcoder& transcoder )
 {
 	std::ifstream configFile( configFilename.c_str(), std::ifstream::in );
 
@@ -99,8 +99,6 @@ int main( int argc, char** argv )
 		if( verbose )
 			std::cout << "start ..." << std::endl;
 
-		avtranscoder::Profile profiles( true );
-
 		if( verbose )
 			std::cout << "output file: " << argv[2] << std::endl;
 
@@ -111,7 +109,7 @@ int main( int argc, char** argv )
 
 		if( verbose )
 			std::cout << "parse config file" << std::endl;
-		parseConfigFile( inputConfigFile, transcoder, profiles );
+		parseConfigFile( inputConfigFile, transcoder );
 
 		// set verbose of all stream
 		transcoder.setVerbose( verbose );

--- a/app/presetChecker/presetChecker.cpp
+++ b/app/presetChecker/presetChecker.cpp
@@ -1,7 +1,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 #include <AvTranscoder/essenceStream/AvOutputVideo.hpp>
 #include <AvTranscoder/essenceStream/AvOutputAudio.hpp>
@@ -9,7 +9,7 @@
 
 int main( int argc, char** argv )
 {
-	avtranscoder::Profile p;
+	avtranscoder::ProfileLoader p;
 	p.loadProfiles();
 
 	std::cout << p.getProfiles().size() << std::endl;

--- a/src/AvTranscoder/ProfileLoader.cpp
+++ b/src/AvTranscoder/ProfileLoader.cpp
@@ -1,4 +1,4 @@
-#include "Profile.hpp"
+#include "ProfileLoader.hpp"
 
 #include "common.hpp"
 
@@ -16,18 +16,18 @@
 namespace avtranscoder
 {
 
-Profile::Profile( bool autoload )
+ProfileLoader::ProfileLoader( bool autoload )
 {
 	if( autoload )
 		loadProfiles();
 }
 
-void Profile::loadProfile( const std::string& avProfileFile )
+void ProfileLoader::loadProfile( const std::string& avProfileFile )
 {
 	std::ifstream infile;
 	infile.open( avProfileFile.c_str(), std::ifstream::in );
 	
-	Profile::ProfileDesc customProfile;
+	ProfileLoader::Profile customProfile;
 
 	std::string line;
 	while( std::getline( infile, line ) )
@@ -50,7 +50,7 @@ void Profile::loadProfile( const std::string& avProfileFile )
 	}
 }
 
-void Profile::loadProfiles( const std::string& avProfilesPath )
+void ProfileLoader::loadProfiles( const std::string& avProfilesPath )
 {
 	loadXdCamHD422( _profiles );
 	loadDNxHD( _profiles );
@@ -83,11 +83,11 @@ void Profile::loadProfiles( const std::string& avProfilesPath )
 	}
 }
 
-void Profile::update( const ProfileDesc& profile )
+void ProfileLoader::update( const Profile& profile )
 {
 	std::string profileId( profile.find( constants::avProfileIdentificator )->second );
 	size_t profileIndex = 0;
-	for( ProfilesDesc::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
+	for( Profiles::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
 	{
 		if( (*it).find( constants::avProfileIdentificator )->second == profileId )
 		{
@@ -100,16 +100,16 @@ void Profile::update( const ProfileDesc& profile )
 	_profiles.push_back( profile );
 }
 
-const Profile::ProfilesDesc& Profile::getProfiles()
+const ProfileLoader::Profiles& ProfileLoader::getProfiles()
 {
 	return _profiles;
 }
 
-Profile::ProfilesDesc Profile::getFormatProfiles()
+ProfileLoader::Profiles ProfileLoader::getFormatProfiles()
 {
-	ProfilesDesc profiles;
+	Profiles profiles;
 
-	for( ProfilesDesc::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
+	for( Profiles::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
 	{
 		if( (*it).find( constants::avProfileType )->second == constants::avProfileTypeFormat )
 			profiles.push_back( *it );
@@ -118,11 +118,11 @@ Profile::ProfilesDesc Profile::getFormatProfiles()
 	return profiles;
 }
 
-Profile::ProfilesDesc Profile::getVideoProfiles()
+ProfileLoader::Profiles ProfileLoader::getVideoProfiles()
 {
-	ProfilesDesc profiles;
+	Profiles profiles;
 
-	for( ProfilesDesc::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
+	for( Profiles::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
 	{
 		if( (*it).find( constants::avProfileType )->second == constants::avProfileTypeVideo )
 			profiles.push_back( *it );
@@ -131,11 +131,11 @@ Profile::ProfilesDesc Profile::getVideoProfiles()
 	return profiles;
 }
 
-Profile::ProfilesDesc Profile::getAudioProfiles()
+ProfileLoader::Profiles ProfileLoader::getAudioProfiles()
 {
-	ProfilesDesc profiles;
+	Profiles profiles;
 
-	for( ProfilesDesc::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
+	for( Profiles::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
 	{
 		if( (*it).find( constants::avProfileType )->second == constants::avProfileTypeAudio )
 			profiles.push_back( *it );
@@ -144,9 +144,9 @@ Profile::ProfilesDesc Profile::getAudioProfiles()
 	return profiles;
 }
 
-Profile::ProfileDesc& Profile::getProfile( const std::string& searchProfile )
+ProfileLoader::Profile& ProfileLoader::getProfile( const std::string& searchProfile )
 {
-	for( ProfilesDesc::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
+	for( Profiles::iterator it = _profiles.begin(); it != _profiles.end(); ++it )
 	{
 		if( (*it).find( constants::avProfileIdentificator )->second == searchProfile )
 		{

--- a/src/AvTranscoder/ProfileLoader.hpp
+++ b/src/AvTranscoder/ProfileLoader.hpp
@@ -28,38 +28,31 @@ namespace constants
 	const std::string avProfileChannel = "ac";
 }
 
-class AvExport Profile
+class AvExport ProfileLoader
 {
 public:
-
-
-public:
-	// typedef std::pair< std::string, std::string > KeyDesc;
-	typedef std::map< std::string, std::string > ProfileDesc;
-	typedef std::vector< ProfileDesc > ProfilesDesc;
+	typedef std::map< std::string, std::string > Profile;
+	typedef std::vector< Profile > Profiles;
 
 public:
-	Profile( bool autoload = false );
+	ProfileLoader( bool autoload = false );
 
 	void loadProfiles( const std::string& avProfilesPath = "" );
 	void loadProfile( const std::string& avProfileFile );
 
-	void update( const ProfileDesc& profile );
+	void update( const Profile& profile );
 	
-	const ProfilesDesc& getProfiles();
+	const Profiles& getProfiles();
 
-	ProfilesDesc getFormatProfiles();
-	ProfilesDesc getVideoProfiles();
-	ProfilesDesc getAudioProfiles();
+	Profiles getFormatProfiles();
+	Profiles getVideoProfiles();
+	Profiles getAudioProfiles();
 
-	ProfileDesc& getProfile( const std::string& searchProfile );
+	Profile& getProfile( const std::string& searchProfile );
 
 private:
-	ProfilesDesc _profiles;
-
+	Profiles _profiles;
 };
-
-
 
 }
 #endif

--- a/src/AvTranscoder/avTranscoder.i
+++ b/src/AvTranscoder/avTranscoder.i
@@ -13,7 +13,7 @@
 %include "AvTranscoder/swig/avRational.i"
 
 %{
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 #include <AvTranscoder/frame/Pixel.hpp>
 #include <AvTranscoder/frame/Frame.hpp>
@@ -26,8 +26,6 @@
 #include <AvTranscoder/codec/DataCodec.hpp>
 
 #include <AvTranscoder/mediaProperty/mediaProperty.hpp>
-
-#include <AvTranscoder/Profile.hpp>
 
 #include <AvTranscoder/codedStream/IOutputStream.hpp>
 #include <AvTranscoder/codedStream/AvOutputStream.hpp>
@@ -65,7 +63,7 @@ namespace std {
 
 %include "AvTranscoder/progress/progress.i"
 
-%include <AvTranscoder/Profile.hpp>
+%include <AvTranscoder/ProfileLoader.hpp>
 
 %include <AvTranscoder/frame/Pixel.hpp>
 %include <AvTranscoder/frame/Frame.hpp>
@@ -78,8 +76,6 @@ namespace std {
 %include <AvTranscoder/codec/DataCodec.hpp>
 
 %include <AvTranscoder/mediaProperty/mediaProperty.hpp>
-
-%include <AvTranscoder/Profile.hpp>
 
 %include <AvTranscoder/codedStream/IOutputStream.hpp>
 %include <AvTranscoder/codedStream/AvOutputStream.hpp>

--- a/src/AvTranscoder/essenceStream/AvInputVideo.cpp
+++ b/src/AvTranscoder/essenceStream/AvInputVideo.cpp
@@ -127,11 +127,11 @@ void AvInputVideo::flushDecoder()
 	avcodec_flush_buffers( _codec.getAVCodecContext() );
 }
 
-void AvInputVideo::setProfile( const Profile::ProfileDesc& desc )
+void AvInputVideo::setProfile( const ProfileLoader::Profile& profile )
 {
 	Context codecContext( _codec.getAVCodecContext() );
 
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||

--- a/src/AvTranscoder/essenceStream/AvInputVideo.hpp
+++ b/src/AvTranscoder/essenceStream/AvInputVideo.hpp
@@ -3,7 +3,7 @@
 
 #include "IInputEssence.hpp"
 #include <AvTranscoder/codec/VideoCodec.hpp>
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 struct AVFrame;
 
@@ -25,7 +25,7 @@ public:
 
 	void flushDecoder();
 	
-	void setProfile( const Profile::ProfileDesc& desc );
+	void setProfile( const ProfileLoader::Profile& profile );
 	
 private:
 	AvInputStream*     _inputStream;

--- a/src/AvTranscoder/essenceStream/AvOutputAudio.cpp
+++ b/src/AvTranscoder/essenceStream/AvOutputAudio.cpp
@@ -171,20 +171,20 @@ bool AvOutputAudio::encodeFrame( Frame& codedFrame )
 #endif
 }
 
-void AvOutputAudio::setProfile( const Profile::ProfileDesc& desc, const AudioFrameDesc& frameDesc  )
+void AvOutputAudio::setProfile( const ProfileLoader::Profile& profile, const AudioFrameDesc& frameDesc  )
 {
-	if( ! desc.count( constants::avProfileCodec ) || 		
-		! desc.count( constants::avProfileSampleFormat ) )
+	if( ! profile.count( constants::avProfileCodec ) || 		
+		! profile.count( constants::avProfileSampleFormat ) )
 	{
-		throw std::runtime_error( "The profile " + desc.find( constants::avProfileIdentificatorHuman )->second + " is invalid." );
+		throw std::runtime_error( "The profile " + profile.find( constants::avProfileIdentificatorHuman )->second + " is invalid." );
 	}
 	
-	_codec.setCodec( eCodecTypeEncoder, desc.find( constants::avProfileCodec )->second );
+	_codec.setCodec( eCodecTypeEncoder, profile.find( constants::avProfileCodec )->second );
 	_codec.setAudioParameters( frameDesc );
 
 	Context codecContext( _codec.getAVCodecContext() );
 	
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||
@@ -206,7 +206,7 @@ void AvOutputAudio::setProfile( const Profile::ProfileDesc& desc, const AudioFra
 
 	setup();
 
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||

--- a/src/AvTranscoder/essenceStream/AvOutputAudio.hpp
+++ b/src/AvTranscoder/essenceStream/AvOutputAudio.hpp
@@ -3,7 +3,7 @@
 
 #include "IOutputEssence.hpp"
 #include <AvTranscoder/codec/AudioCodec.hpp>
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 namespace avtranscoder
 {
@@ -25,7 +25,7 @@ public:
 	 */
 	bool encodeFrame( Frame& codedFrame );
 	
-	void setProfile( const Profile::ProfileDesc& desc, const AudioFrameDesc& frameDesc );
+	void setProfile( const ProfileLoader::Profile& profile, const AudioFrameDesc& frameDesc );
 
 	ICodec& getCodec() { return _codec; }
 	AudioCodec& getAudioCodec() { return _codec; }

--- a/src/AvTranscoder/essenceStream/AvOutputVideo.cpp
+++ b/src/AvTranscoder/essenceStream/AvOutputVideo.cpp
@@ -172,25 +172,25 @@ bool AvOutputVideo::encodeFrame( Frame& codedFrame )
 #endif
 }
 
-void AvOutputVideo::setProfile( const Profile::ProfileDesc& desc, const avtranscoder::VideoFrameDesc& frameDesc )
+void AvOutputVideo::setProfile( const ProfileLoader::Profile& profile, const avtranscoder::VideoFrameDesc& frameDesc )
 {
-	if( ! desc.count( constants::avProfileCodec ) ||
-		! desc.count( constants::avProfilePixelFormat ) || 
-		! desc.count( constants::avProfileFrameRate ) )
+	if( ! profile.count( constants::avProfileCodec ) ||
+		! profile.count( constants::avProfilePixelFormat ) || 
+		! profile.count( constants::avProfileFrameRate ) )
 	{
-		throw std::runtime_error( "The profile " + desc.find( constants::avProfileIdentificatorHuman )->second + " is invalid." );
+		throw std::runtime_error( "The profile " + profile.find( constants::avProfileIdentificatorHuman )->second + " is invalid." );
 	}
 	
-	_codec.setCodec( eCodecTypeEncoder, desc.find( constants::avProfileCodec )->second );
+	_codec.setCodec( eCodecTypeEncoder, profile.find( constants::avProfileCodec )->second );
 
-	const size_t frameRate = std::strtoul( desc.find( constants::avProfileFrameRate )->second.c_str(), NULL, 0 );
+	const size_t frameRate = std::strtoul( profile.find( constants::avProfileFrameRate )->second.c_str(), NULL, 0 );
 	_codec.setTimeBase( 1, frameRate );
 
 	_codec.setImageParameters( frameDesc );
 
 	Context codecContext( _codec.getAVCodecContext() );
 	
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||
@@ -213,7 +213,7 @@ void AvOutputVideo::setProfile( const Profile::ProfileDesc& desc, const avtransc
 
 	setup();
 
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||

--- a/src/AvTranscoder/essenceStream/AvOutputVideo.hpp
+++ b/src/AvTranscoder/essenceStream/AvOutputVideo.hpp
@@ -3,7 +3,7 @@
 
 #include "IOutputEssence.hpp"
 #include <AvTranscoder/codec/VideoCodec.hpp>
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 namespace avtranscoder
 {
@@ -25,7 +25,7 @@ public:
 	 */
 	bool encodeFrame( Frame& codedFrame );
 
-	void setProfile( const Profile::ProfileDesc& desc, const avtranscoder::VideoFrameDesc& frameDesc );
+	void setProfile( const ProfileLoader::Profile& profile, const avtranscoder::VideoFrameDesc& frameDesc );
 	
 	ICodec& getCodec() { return _codec; }
 	VideoCodec& getVideoCodec() { return _codec; }

--- a/src/AvTranscoder/file/InputFile.cpp
+++ b/src/AvTranscoder/file/InputFile.cpp
@@ -211,11 +211,11 @@ bool InputFile::getReadStream( const size_t streamIndex )
 	return _inputStreams.at( streamIndex )->getBufferred();
 }
 
-void InputFile::setProfile( const Profile::ProfileDesc& desc )
+void InputFile::setProfile( const ProfileLoader::Profile& profile )
 {	
 	Context formatContext( _formatContext );
 	
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||

--- a/src/AvTranscoder/file/InputFile.hpp
+++ b/src/AvTranscoder/file/InputFile.hpp
@@ -12,7 +12,7 @@
 
 #include <AvTranscoder/progress/IProgress.hpp>
 
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 #include <string>
 #include <vector>
@@ -119,9 +119,9 @@ public:
 	
 	/**
 	 * @brief Set the format of the input file
-	 * @param desc: the profile of the input format
+	 * @param profile: the profile of the input format
 	 */
-	virtual void setProfile( const Profile::ProfileDesc& desc );
+	virtual void setProfile( const ProfileLoader::Profile& profile );
 
 protected:
 	AVFormatContext*            _formatContext;

--- a/src/AvTranscoder/file/OutputFile.cpp
+++ b/src/AvTranscoder/file/OutputFile.cpp
@@ -220,22 +220,22 @@ void OutputFile::addMetadata( const std::string& key, const std::string& value )
 	}
 }
 
-void OutputFile::setProfile( const Profile::ProfileDesc& desc )
+void OutputFile::setProfile( const ProfileLoader::Profile& profile )
 {
-	if( ! desc.count( constants::avProfileFormat ) )
+	if( ! profile.count( constants::avProfileFormat ) )
 	{
-		throw std::runtime_error( "The profile " + desc.find( constants::avProfileIdentificatorHuman )->second + " is invalid." );
+		throw std::runtime_error( "The profile " + profile.find( constants::avProfileIdentificatorHuman )->second + " is invalid." );
 	}
 	
-	if( ! matchFormat( desc.find( constants::avProfileFormat )->second, _filename ) )
+	if( ! matchFormat( profile.find( constants::avProfileFormat )->second, _filename ) )
 	{
 		throw std::runtime_error( "Invalid format according to the file extension." );
 	}
-	_outputFormat = av_guess_format( desc.find( constants::avProfileFormat )->second.c_str(), _filename.c_str(), NULL);
+	_outputFormat = av_guess_format( profile.find( constants::avProfileFormat )->second.c_str(), _filename.c_str(), NULL);
 	
 	Context formatContext( _formatContext );
 	
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||
@@ -256,7 +256,7 @@ void OutputFile::setProfile( const Profile::ProfileDesc& desc )
 	
 	setup();
 	
-	for( Profile::ProfileDesc::const_iterator it = desc.begin(); it != desc.end(); ++it )
+	for( ProfileLoader::Profile::const_iterator it = profile.begin(); it != profile.end(); ++it )
 	{
 		if( (*it).first == constants::avProfileIdentificator ||
 			(*it).first == constants::avProfileIdentificatorHuman ||

--- a/src/AvTranscoder/file/OutputFile.hpp
+++ b/src/AvTranscoder/file/OutputFile.hpp
@@ -11,7 +11,7 @@
 
 #include <AvTranscoder/codedStream/AvOutputStream.hpp>
 
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 #include <string>
 #include <vector>
@@ -98,7 +98,7 @@ public:
 	 * @brief Set the format of the output file
 	 * @param desc: the profile of the output format
 	 */
-	virtual void setProfile( const Profile::ProfileDesc& desc );
+	virtual void setProfile( const ProfileLoader::Profile& profile );
 	
 	/**
 	 * @brief Add metadata to the output file.

--- a/src/AvTranscoder/frame/AudioFrame.hpp
+++ b/src/AvTranscoder/frame/AudioFrame.hpp
@@ -2,7 +2,7 @@
 #define _AV_TRANSCODER_DATA_AUDIO_FRAME_HPP_
 
 #include "Frame.hpp"
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 namespace avtranscoder
 {
@@ -28,10 +28,10 @@ public:
 		return ( _sampleRate / _fps ) * _channels * av_get_bytes_per_sample( _sampleFormat );
 	}
 	
-	void setParameters( const Profile::ProfileDesc& desc )
+	void setParameters( const ProfileLoader::Profile& profile )
 	{
-		if( desc.find( constants::avProfileSampleFormat ) != desc.end() )
-			setSampleFormat( desc.find( constants::avProfileSampleFormat )->second );
+		if( profile.find( constants::avProfileSampleFormat ) != profile.end() )
+			setSampleFormat( profile.find( constants::avProfileSampleFormat )->second );
 	}
 
 	size_t getSampleRate() const { return _sampleRate; }

--- a/src/AvTranscoder/frame/VideoFrame.hpp
+++ b/src/AvTranscoder/frame/VideoFrame.hpp
@@ -3,7 +3,7 @@
 
 #include "Frame.hpp"
 #include "Pixel.hpp"
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 extern "C" {
 #include <libavutil/pixdesc.h>
@@ -44,10 +44,10 @@ public:
 	void setDar( const size_t num, const size_t den ) { _displayAspectRatio.num = num; _displayAspectRatio.den = den; }
 	void setDar( const Rational ratio ) { _displayAspectRatio = ratio; }
 	
-	void setParameters( const Profile::ProfileDesc& desc )
+	void setParameters( const ProfileLoader::Profile& profile )
 	{
-		if( desc.find( constants::avProfilePixelFormat ) != desc.end() )
-			setPixel( Pixel( desc.find( constants::avProfilePixelFormat )->second.c_str() ) );
+		if( profile.find( constants::avProfilePixelFormat ) != profile.end() )
+			setPixel( Pixel( profile.find( constants::avProfilePixelFormat )->second.c_str() ) );
 	}
 
 	size_t               getWidth ()    const { return _width;  }
@@ -94,7 +94,7 @@ public:
 		_dataBuffer = DataBuffer( ref.getDataSize(), 0 );
 	}
 
-	const VideoFrameDesc&     desc() const    { return _videoFrameDesc; }
+	const VideoFrameDesc& desc() const { return _videoFrameDesc; }
 
 private:
 	const VideoFrameDesc _videoFrameDesc;

--- a/src/AvTranscoder/profile/Avi.hpp
+++ b/src/AvTranscoder/profile/Avi.hpp
@@ -4,9 +4,9 @@
 namespace avtranscoder
 {
 
-void loadAvi( Profile::ProfilesDesc& profiles )
+void loadAvi( ProfileLoader::Profiles& profiles )
 {
-	Profile::ProfileDesc avi;
+	ProfileLoader::Profile avi;
 	avi[ constants::avProfileIdentificator ] = "avi";
 	avi[ constants::avProfileIdentificatorHuman ] = "AVI (Audio Video Interleaved)";
 	avi[ constants::avProfileType ] = constants::avProfileTypeFormat;

--- a/src/AvTranscoder/profile/DNxHD.hpp
+++ b/src/AvTranscoder/profile/DNxHD.hpp
@@ -4,9 +4,9 @@
 namespace avtranscoder
 {
 
-void loadDNxHD( Profile::ProfilesDesc& profiles )
+void loadDNxHD( ProfileLoader::Profiles& profiles )
 {
-	Profile::ProfileDesc dnxhd120;
+	ProfileLoader::Profile dnxhd120;
 	dnxhd120[ constants::avProfileIdentificator ] = "dnxhd120";
 	dnxhd120[ constants::avProfileIdentificatorHuman ] = "DNxHD 120";
 	dnxhd120[ constants::avProfileType ] = constants::avProfileTypeVideo;
@@ -16,7 +16,7 @@ void loadDNxHD( Profile::ProfilesDesc& profiles )
 	dnxhd120[ "g" ] = "1";
 	dnxhd120[ constants::avProfileFrameRate ] = "25";
 
-	Profile::ProfileDesc dnxhd185;
+	ProfileLoader::Profile dnxhd185;
 	dnxhd185[ constants::avProfileIdentificator ] = "dnxhd185";
 	dnxhd185[ constants::avProfileIdentificatorHuman ] = "DNxHD 185";
 	dnxhd185[ constants::avProfileType ] = constants::avProfileTypeVideo;
@@ -26,7 +26,7 @@ void loadDNxHD( Profile::ProfilesDesc& profiles )
 	dnxhd185[ "g" ] = "1";
 	dnxhd185[ constants::avProfileFrameRate ] = "25";
 
-	Profile::ProfileDesc dnxhd185x;
+	ProfileLoader::Profile dnxhd185x;
 	dnxhd185x[ constants::avProfileIdentificator ] = "dnxhd185x";
 	dnxhd185x[ constants::avProfileIdentificatorHuman ] = "DNxHD 185 X";
 	dnxhd185x[ constants::avProfileType ] = constants::avProfileTypeVideo;

--- a/src/AvTranscoder/profile/Mkv.hpp
+++ b/src/AvTranscoder/profile/Mkv.hpp
@@ -4,9 +4,9 @@
 namespace avtranscoder
 {
 
-void loadMkv( Profile::ProfilesDesc& profiles )
+void loadMkv( ProfileLoader::Profiles& profiles )
 {
-	Profile::ProfileDesc mkv;
+	ProfileLoader::Profile mkv;
 	mkv[ constants::avProfileIdentificator ] = "mkv";
 	mkv[ constants::avProfileIdentificatorHuman ] = "Matroska";
 	mkv[ constants::avProfileType ] = constants::avProfileTypeFormat;

--- a/src/AvTranscoder/profile/Wave.hpp
+++ b/src/AvTranscoder/profile/Wave.hpp
@@ -4,9 +4,9 @@
 namespace avtranscoder
 {
 
-void loadWave( Profile::ProfilesDesc& profiles )
+void loadWave( ProfileLoader::Profiles& profiles )
 {
-	Profile::ProfileDesc wave48k;
+	ProfileLoader::Profile wave48k;
 	wave48k[ constants::avProfileType ] = constants::avProfileTypeAudio;
 	wave48k[ constants::avProfileSampleRate ] = "48000";
 

--- a/src/AvTranscoder/profile/XdCamHd422.hpp
+++ b/src/AvTranscoder/profile/XdCamHd422.hpp
@@ -4,9 +4,9 @@
 namespace avtranscoder
 {
 
-void loadXdCamHD422( Profile::ProfilesDesc& profiles )
+void loadXdCamHD422( ProfileLoader::Profiles& profiles )
 {
-	Profile::ProfileDesc xdCamHd422;
+	ProfileLoader::Profile xdCamHd422;
 
 	xdCamHd422[ constants::avProfileIdentificator ] = "xdcamhd422";
 	xdCamHd422[ constants::avProfileIdentificatorHuman ] = "XdCamHD 422";

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -67,7 +67,7 @@ StreamTranscoder::StreamTranscoder(
 StreamTranscoder::StreamTranscoder(
 		IInputStream& inputStream,
 		OutputFile& outputFile,
-		const Profile::ProfileDesc& profile,
+		const ProfileLoader::Profile& profile,
 		const int subStreamIndex,
 		const size_t offset
 	)
@@ -164,7 +164,7 @@ StreamTranscoder::StreamTranscoder(
 StreamTranscoder::StreamTranscoder(
 		const ICodec& inputCodec,
 		OutputFile& outputFile,
-		const Profile::ProfileDesc& profile
+		const ProfileLoader::Profile& profile
 	)
 	: _inputStream( NULL )
 	, _outputStream( NULL )

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -11,7 +11,7 @@
 
 #include <AvTranscoder/file/OutputFile.hpp>
 
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 namespace avtranscoder
 {
@@ -30,13 +30,13 @@ public:
 	/**
 	 * @brief transcode stream
 	 **/
-	StreamTranscoder( IInputStream& inputStream, OutputFile& outputFile, const Profile::ProfileDesc& profile, const int subStreamIndex = -1, const size_t offset = 0 );
+	StreamTranscoder( IInputStream& inputStream, OutputFile& outputFile, const ProfileLoader::Profile& profile, const int subStreamIndex = -1, const size_t offset = 0 );
 
 	/**
 	 * @brief encode from a generated stream
 	 * @note offset feature has no sense here
 	 **/
-	StreamTranscoder( const ICodec& inputCodec, OutputFile& outputFile, const Profile::ProfileDesc& profile );
+	StreamTranscoder( const ICodec& inputCodec, OutputFile& outputFile, const ProfileLoader::Profile& profile );
 
 	~StreamTranscoder();
 

--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -11,7 +11,7 @@ Transcoder::Transcoder( OutputFile& outputFile )
 	: _outputFile( outputFile )
 	, _inputFiles()
 	, _streamTranscoders()
-	, _profile( true )
+	, _profileLoader( true )
 	, _outputFps( 25 )
 	, _eProcessMethod ( eProcessMethodLongest )
 	, _mainStreamIndex( 0 )
@@ -42,7 +42,7 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, con
 		return;
 	}
 
-	Profile::ProfileDesc& transcodeProfile = _profile.getProfile( profileName );
+	ProfileLoader::Profile& transcodeProfile = _profileLoader.getProfile( profileName );
 	add( filename, streamIndex, transcodeProfile, offset );
 }
 
@@ -63,13 +63,13 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, con
 		return;
 	}
 	
-	Profile::ProfileDesc& transcodeProfile = _profile.getProfile( profileName );
+	ProfileLoader::Profile& transcodeProfile = _profileLoader.getProfile( profileName );
 	add( filename, streamIndex, transcodeProfile, codec, offset );
 }
 
-void Transcoder::add( const std::string& filename, const size_t streamIndex, Profile::ProfileDesc& profileDesc, const size_t offset )
+void Transcoder::add( const std::string& filename, const size_t streamIndex, ProfileLoader::Profile& profile, const size_t offset )
 {
-	_profile.update( profileDesc );
+	_profileLoader.update( profile );
 	if( ! filename.length() )
 	{
 		std::cerr << "can't add a stream with no filename indicated" << std::endl;
@@ -78,23 +78,23 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, Pro
 
 	if( _verbose )
 		std::cout << "add transcoding stream" << std::endl;
-	addTranscodeStream( filename, streamIndex, profileDesc, offset );
+	addTranscodeStream( filename, streamIndex, profile, offset );
 }
 
-void Transcoder::add( const std::string& filename, const size_t streamIndex, Profile::ProfileDesc& profileDesc, ICodec& codec, const size_t offset )
+void Transcoder::add( const std::string& filename, const size_t streamIndex, ProfileLoader::Profile& profile, ICodec& codec, const size_t offset )
 {
-	_profile.update( profileDesc );
+	_profileLoader.update( profile );
 	if( ! filename.length() )
 	{
 		if( _verbose )
 			std::cout << "add a generated stream" << std::endl;
-		addDummyStream( profileDesc, codec );
+		addDummyStream( profile, codec );
 		return;
 	}
 	
 	if( _verbose )
 		std::cout << "add transcoding stream" << std::endl;
-	addTranscodeStream( filename, streamIndex, profileDesc, offset );
+	addTranscodeStream( filename, streamIndex, profile, offset );
 }
 
 void Transcoder::add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, const std::string& profileName, const size_t offset )
@@ -114,7 +114,7 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, con
 		return;
 	}
 
-	Profile::ProfileDesc& transcodeProfile = _profile.getProfile( profileName );
+	ProfileLoader::Profile& transcodeProfile = _profileLoader.getProfile( profileName );
 	add( filename, streamIndex, subStreamIndex, transcodeProfile, offset );
 }
 
@@ -141,17 +141,17 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, con
 		return;
 	}
 
-	Profile::ProfileDesc& transcodeProfile = _profile.getProfile( profileName );
+	ProfileLoader::Profile& transcodeProfile = _profileLoader.getProfile( profileName );
 	add( filename, streamIndex, subStreamIndex, transcodeProfile, codec, offset );
 }
 
-void Transcoder::add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, Profile::ProfileDesc& profileDesc, const size_t offset )
+void Transcoder::add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, ProfileLoader::Profile& profile, const size_t offset )
 {
-	_profile.update( profileDesc );
+	_profileLoader.update( profile );
 	
 	if( subStreamIndex < 0 )
 	{
-		add( filename, streamIndex, profileDesc, offset );
+		add( filename, streamIndex, profile, offset );
 		return;
 	}
 	
@@ -164,16 +164,16 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, con
 
 	if( _verbose )
 		std::cout << "add transcoding stream for substream " << subStreamIndex << std::endl;
-	addTranscodeStream( filename, streamIndex, subStreamIndex, profileDesc, offset );
+	addTranscodeStream( filename, streamIndex, subStreamIndex, profile, offset );
 }
 
-void Transcoder::add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, Profile::ProfileDesc& profileDesc, ICodec& codec, const size_t offset )
+void Transcoder::add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, ProfileLoader::Profile& profile, ICodec& codec, const size_t offset )
 {
-	_profile.update( profileDesc );
+	_profileLoader.update( profile );
 	
 	if( subStreamIndex < 0 )
 	{
-		add( filename, streamIndex, profileDesc );
+		add( filename, streamIndex, profile );
 		return;
 	}
 	
@@ -181,13 +181,13 @@ void Transcoder::add( const std::string& filename, const size_t streamIndex, con
 	{
 		if( _verbose )
 			std::cout << "add a generated stream" << std::endl;
-		addDummyStream( profileDesc, codec );
+		addDummyStream( profile, codec );
 		return;
 	}
 
 	if( _verbose )
 		std::cout << "add transcoding stream for substream " << subStreamIndex << std::endl;
-	addTranscodeStream( filename, streamIndex, subStreamIndex, profileDesc, offset );
+	addTranscodeStream( filename, streamIndex, subStreamIndex, profile, offset );
 }
 
 void Transcoder::add( StreamTranscoder& stream )
@@ -335,7 +335,7 @@ void Transcoder::addRewrapStream( const std::string& filename, const size_t stre
 	_streamTranscoders.push_back( new StreamTranscoder( referenceFile->getStream( streamIndex ), _outputFile ) );
 }
 
-void Transcoder::addTranscodeStream( const std::string& filename, const size_t streamIndex, Profile::ProfileDesc& profile, const size_t offset )
+void Transcoder::addTranscodeStream( const std::string& filename, const size_t streamIndex, ProfileLoader::Profile& profile, const size_t offset )
 {
 	InputFile* referenceFile = addInputFile( filename, streamIndex );
 
@@ -357,7 +357,7 @@ void Transcoder::addTranscodeStream( const std::string& filename, const size_t s
 	}
 }
 
-void Transcoder::addTranscodeStream( const std::string& filename, const size_t streamIndex, const size_t subStreamIndex, Profile::ProfileDesc& profile, const size_t offset )
+void Transcoder::addTranscodeStream( const std::string& filename, const size_t streamIndex, const size_t subStreamIndex, ProfileLoader::Profile& profile, const size_t offset )
 {
 	InputFile* referenceFile = addInputFile( filename, streamIndex );
 
@@ -379,7 +379,7 @@ void Transcoder::addTranscodeStream( const std::string& filename, const size_t s
 	}
 }
 
-void Transcoder::addDummyStream( const Profile::ProfileDesc& profile, const ICodec& codec )
+void Transcoder::addDummyStream( const ProfileLoader::Profile& profile, const ICodec& codec )
 {
 	if( ! profile.count( constants::avProfileType ) )
 		throw std::runtime_error( "unable to found stream type (audio, video, etc.)" );

--- a/src/AvTranscoder/transcoder/Transcoder.hpp
+++ b/src/AvTranscoder/transcoder/Transcoder.hpp
@@ -11,9 +11,7 @@
 #include <AvTranscoder/essenceStream/GeneratorAudio.hpp>
 #include <AvTranscoder/essenceStream/GeneratorVideo.hpp>
 
-#include <AvTranscoder/progress/IProgress.hpp>
-
-#include <AvTranscoder/Profile.hpp>
+#include <AvTranscoder/ProfileLoader.hpp>
 
 #include "StreamTranscoder.hpp"
 
@@ -65,11 +63,11 @@ public:
 	 * @brief Add a stream and set a custom profile
 	 * @note Profile will be updated, be sure to pass unique profile name.
 	 */
-	void add( const std::string& filename, const size_t streamIndex, Profile::ProfileDesc& profileDesc, const size_t offset = 0 );
+	void add( const std::string& filename, const size_t streamIndex, ProfileLoader::Profile& profile, const size_t offset = 0 );
 	/*
 	 * @note If filename is empty, add a generated stream.
 	 */
-	void add( const std::string& filename, const size_t streamIndex, Profile::ProfileDesc& profileDesc, ICodec& codec, const size_t offset = 0  );
+	void add( const std::string& filename, const size_t streamIndex, ProfileLoader::Profile& profile, ICodec& codec, const size_t offset = 0  );
 	
 	/**
 	 * @brief Add a stream and set a profile
@@ -88,11 +86,11 @@ public:
 	 * @note Profile will be updated, be sure to pass unique profile name.
 	 * @note If subStreamIndex is negative, no substream is selected it's the stream.
 	 */
-	void add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, Profile::ProfileDesc& profileDesc, const size_t offset = 0 );
+	void add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, ProfileLoader::Profile& profile, const size_t offset = 0 );
 	/**
 	 * @note If filename is empty, add a generated stream.
 	 */
-	void add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, Profile::ProfileDesc& profileDesc, ICodec& codec, const size_t offset = 0  );
+	void add( const std::string& filename, const size_t streamIndex, const int subStreamIndex, ProfileLoader::Profile& profile, ICodec& codec, const size_t offset = 0  );
 
 	/**
 	 * @brief Add the stream
@@ -143,11 +141,11 @@ private:
 
 	void addRewrapStream( const std::string& filename, const size_t streamIndex );
 
-	void addTranscodeStream( const std::string& filename, const size_t streamIndex, Profile::ProfileDesc& profile, const size_t offset = 0 );
+	void addTranscodeStream( const std::string& filename, const size_t streamIndex, ProfileLoader::Profile& profile, const size_t offset = 0 );
 
-	void addTranscodeStream( const std::string& filename, const size_t streamIndex, const size_t subStreamIndex, Profile::ProfileDesc& profile, const size_t offset = 0 );
+	void addTranscodeStream( const std::string& filename, const size_t streamIndex, const size_t subStreamIndex, ProfileLoader::Profile& profile, const size_t offset = 0 );
 
-	void addDummyStream( const Profile::ProfileDesc& profile, const ICodec& codec );
+	void addDummyStream( const ProfileLoader::Profile& profile, const ICodec& codec );
 
 	InputFile* addInputFile( const std::string& filename, const size_t streamIndex );
 
@@ -174,7 +172,7 @@ private:
 
 	std::vector< StreamTranscoder* > _streamTranscoders;  ///< The streams of the output media file after process.
 
-	Profile _profile;  ///< Objet to get existing profiles, and add new ones for the Transcoder.
+	ProfileLoader _profileLoader;  ///< Objet to get existing profiles, and add new ones for the Transcoder.
 
 	double _outputFps;
 


### PR DESCRIPTION
- Avoid misunderstood with users: a profile is a map<string, string>,
  and a ProfileLoader manages a list of profiles.
- Rename typedef:
  - ProfileDesc to Profile.
  - ProfilesDesc to Profiles.
