### PR TITLE
Transcoding: empty encoder buffer at the end of the process

### DIFF
--- a/src/AvTranscoder/essenceStream/AvInputVideo.cpp
+++ b/src/AvTranscoder/essenceStream/AvInputVideo.cpp
@@ -22,7 +22,6 @@ AvInputVideo::AvInputVideo( AvInputStream& inputStream )
 	, _inputStream   ( &inputStream )
 	, _codec( eCodecTypeDecoder, inputStream.getVideoCodec().getCodecId() )
 	, _frame         ( NULL )
-	, _selectedStream( inputStream.getStreamIndex() )
 {
 }
 
@@ -88,9 +87,9 @@ bool AvInputVideo::readNextFrame( Frame& frameBuffer )
 
 		bool nextPacketRead = _inputStream->readNextPacket( data );
 
-		packet.stream_index = _selectedStream;
+		packet.stream_index = _inputStream->getStreamIndex();
 		packet.data = nextPacketRead ? data.getPtr(): NULL;
-		packet.size = nextPacketRead ? data.getSize(): 0;
+		packet.size = data.getSize();
 
 		int ret = avcodec_decode_video2( _codec.getAVCodecContext(), _frame, &got_frame, &packet );
 		

--- a/src/AvTranscoder/essenceStream/AvInputVideo.hpp
+++ b/src/AvTranscoder/essenceStream/AvInputVideo.hpp
@@ -31,8 +31,6 @@ private:
 	AvInputStream*     _inputStream;
 	VideoCodec _codec;
 	AVFrame*           _frame;
-
-	int                _selectedStream;
 };
 
 }


### PR DESCRIPTION
Return bufferized framed from the encoder at the end of the transcoding process.
issue #58
