### PR TITLE
Travis: added libbz2 to dependencies to deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ after_success:
   - if [ ${ENABLE_COVERAGE} ]; then ./tools/travis.gcc.generate.coverage.sh; fi
 
 before_deploy:
+  # copy libbz2, external dependency of libavformat
+  - if [ ${TRAVIS_OS_NAME} = "linux" ]; then cp /lib/x86_64-linux-gnu/{libbz2.so.1,libbz2.so.1.0,libbz2.so.1.0.4} ${DEPENDENCY_INSTALL_PATH}/lib; fi
   # create archive
   - cd ${TRAVIS_BUILD_DIR}
   - tar -cvzf avtranscoder-${TRAVIS_OS_NAME}-${CC}-${DEPENDENCY_MODE}.tgz ${DEPENDENCY_INSTALL} ${AVTRANSCODER_INSTALL}


### PR DESCRIPTION
- libavformat depends on libbz2.so.1.0
- Most linux distribution has libbz2.so, but sometimes without the
  symbolic link 'libbz2.so.1.0'. It causes that our deployed libavformat
  cannot be loaded on Fedora distribution for example.
- This commit fixes this issue.
