### PR TITLE
Swig: ignore custom types which are not bound

### DIFF
--- a/src/AvTranscoder/Option.hpp
+++ b/src/AvTranscoder/Option.hpp
@@ -118,6 +118,7 @@ private:
 typedef std::vector<Option> OptionArray;
 typedef std::map<std::string, Option> OptionMap;  ///< Key: option name / value: option
 
+#ifndef SWIG
 /**
  * @param outOptions: map or array of options
  * @param av_class: a libav context (could be an AVFormatContext or an AVCodecContext).
@@ -125,6 +126,7 @@ typedef std::map<std::string, Option> OptionMap;  ///< Key: option name / value:
  */
 void AvExport loadOptions( OptionMap& outOptions, void* av_class, int req_flags = 0 );
 void AvExport loadOptions( OptionArray& outOptions, void* av_class, int req_flags = 0 );
+#endif
 
 }
 

--- a/src/AvTranscoder/codec/ICodec.hpp
+++ b/src/AvTranscoder/codec/ICodec.hpp
@@ -44,8 +44,9 @@ public:
 	int getLatency() const;
 
 	OptionArray getOptions();  ///< Get options as array
+#ifndef SWIG
 	OptionMap& getOptionsMap() { return _options; }  ///< Get options as map
-
+#endif
 	Option& getOption( const std::string& optionName ) { return _options.at(optionName); }
 	
 #ifndef SWIG

--- a/src/AvTranscoder/file/FormatContext.hpp
+++ b/src/AvTranscoder/file/FormatContext.hpp
@@ -88,8 +88,9 @@ public:
 	size_t getStartTime() const { return _avFormatContext->start_time; }
 
 	OptionArray getOptions();  ///< Get options as array
+#ifndef SWIG
 	OptionMap& getOptionsMap() { return _options; }  ///< Get options as map
-
+#endif
 	Option& getOption( const std::string& optionName ) { return _options.at(optionName); }
 
 	/**

--- a/src/AvTranscoder/util.hpp
+++ b/src/AvTranscoder/util.hpp
@@ -48,6 +48,7 @@ AVPixelFormat AvExport getAVPixelFormat( const std::string& pixelFormat );
 */
 AVSampleFormat AvExport getAVSampleFormat( const std::string& sampleFormat );
 
+#ifndef SWIG
 /**
  * @brief Get array of short/long names of all format supported by FFmpeg / libav.
  */
@@ -77,6 +78,7 @@ OptionArrayMap AvExport getVideoCodecOptions();
  * @brief Get the list of options for each audio codec
  */
 OptionArrayMap AvExport getAudioCodecOptions();
+#endif
 
 }
 


### PR DESCRIPTION
Fix #152