### PR TITLE
ProfileLoader: by default load profiles defined as text files at AVPROFILES

### DIFF
--- a/src/AvTranscoder/profile/ProfileLoader.cpp
+++ b/src/AvTranscoder/profile/ProfileLoader.cpp
@@ -9,7 +9,7 @@
 namespace avtranscoder
 {
 
-ProfileLoader::ProfileLoader(bool autoload)
+ProfileLoader::ProfileLoader(const bool autoload)
 {
     if(autoload)
         loadProfiles();

--- a/src/AvTranscoder/profile/ProfileLoader.hpp
+++ b/src/AvTranscoder/profile/ProfileLoader.hpp
@@ -39,7 +39,10 @@ public:
     typedef std::vector<Profile> Profiles;
 
 public:
-    ProfileLoader(bool autoload = false);
+    /**
+     * @param autoload: load profiles defined as text files at AVPROFILES
+     */
+    ProfileLoader(const bool autoload = true);
 
     /**
      * @brief Load profiles from files in avProfilesPath directory


### PR DESCRIPTION
Fix #223