### PR TITLE
StreamProperties: added list of private codec options

### DIFF
--- a/src/AvTranscoder/properties/StreamProperties.cpp
+++ b/src/AvTranscoder/properties/StreamProperties.cpp
@@ -28,8 +28,21 @@ StreamProperties::StreamProperties(const FormatContext& formatContext, const siz
         _codecContext = _formatContext->streams[_streamIndex]->codec;
     }
 
+    // find the decoder
     if(_formatContext && _codecContext)
+    {
         _codec = avcodec_find_decoder(_codecContext->codec_id);
+
+        if(_codec)
+        {
+            // load specific options of the codec
+            if(avcodec_open2(_codecContext, _codec, NULL) == 0)
+            {
+                loadOptions(_options, _codecContext);
+                avcodec_close(_codecContext);
+            }
+        }
+    }
 }
 
 StreamProperties::~StreamProperties()
@@ -96,6 +109,16 @@ std::string StreamProperties::getCodecLongName() const
         throw std::runtime_error("unknown codec long name");
 
     return std::string(_codec->long_name);
+}
+
+std::vector<Option> StreamProperties::getCodecOptions()
+{
+    std::vector<Option> optionsArray;
+    for(OptionMap::iterator it = _options.begin(); it != _options.end(); ++it)
+    {
+        optionsArray.push_back(it->second);
+    }
+    return optionsArray;
 }
 
 PropertyVector StreamProperties::asVector() const

--- a/src/AvTranscoder/properties/StreamProperties.hpp
+++ b/src/AvTranscoder/properties/StreamProperties.hpp
@@ -2,6 +2,7 @@
 #define _AV_TRANSCODER_MEDIA_PROPERTY_STREAM_PROPERTIES_HPP
 
 #include <AvTranscoder/common.hpp>
+#include <AvTranscoder/Option.hpp>
 #include <AvTranscoder/properties/util.hpp>
 #include <AvTranscoder/file/FormatContext.hpp>
 
@@ -26,6 +27,17 @@ public:
     std::string getCodecLongName() const;
 
     const PropertyVector& getMetadatas() const { return _metadatas; }
+
+    /**
+     * @return The list of private codec options.
+     * @see getOptionsMap
+     * @see getOption
+     */
+    OptionArray getCodecOptions();
+#ifndef SWIG
+    OptionMap& getCodecOptionsMap() { return _options; } ///< Get options as map
+#endif
+    Option& getCodecOption(const std::string& optionName) { return _options.at(optionName); }
 
 #ifndef SWIG
     const AVFormatContext& getAVFormatContext() const { return *_formatContext; }
@@ -59,6 +71,8 @@ protected:
 
     size_t _streamIndex;
     PropertyVector _metadatas;
+
+    OptionMap _options;
 };
 
 #ifndef SWIG

--- a/src/AvTranscoder/properties/VideoProperties.cpp
+++ b/src/AvTranscoder/properties/VideoProperties.cpp
@@ -334,7 +334,7 @@ size_t VideoProperties::getBitRate() const
         throw std::runtime_error("cannot compute bit rate: invalid frame size");
 
     // Needed to get the gop size
-    if(_levelAnalysis < eAnalyseLevelFirstGop)
+    if(getGopSize() == 0)
         throw std::runtime_error("cannot compute bit rate: need to get info from the first gop (see eAnalyseLevelFirstGop)");
 
     // discard no frame type when decode

--- a/src/AvTranscoder/properties/VideoProperties.cpp
+++ b/src/AvTranscoder/properties/VideoProperties.cpp
@@ -509,7 +509,7 @@ void VideoProperties::analyseGopStructure(IProgress& progress)
                                 positionOfLastKeyFrame = count;
                         }
 
-                        ++count;
+                        _gopSize = ++count;
                     }
                 }
                 av_free_packet(&pkt);


### PR DESCRIPTION
Do not print them with other properties, since:
* they are very specific options.
* not all of them can be printed.
* we can access them with getter methods (getCodecOptions).