### PR TITLE
Fix filter graph memory leak

### DIFF
--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -52,6 +52,8 @@ public:
      *                               filter 1 -> filter 2 -> output
      *                                 |
      *                      input 2 ---|
+     * @warning the output frame must be cleared once it has been used
+     * @see the av_buffersink_get_frame function documentation
      */
     void process(const std::vector<Frame*>& inputs, Frame& output);
 

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -550,6 +550,10 @@ bool StreamTranscoder::processTranscode()
         LOG_DEBUG("Convert")
         _transform->convert(*_filteredData, *_transformedData);
 
+        // free the filtered AVFrame now it has been converted into another one
+        // @see the av_buffersink_get_frame documentation
+        av_frame_unref(&_filteredData->getAVFrame());
+
         LOG_DEBUG("Encode")
         _outputEncoder->encodeFrame(*_transformedData, data);
     }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -550,9 +550,7 @@ bool StreamTranscoder::processTranscode()
         LOG_DEBUG("Convert")
         _transform->convert(*_filteredData, *_transformedData);
 
-        // free the filtered AVFrame now it has been converted into another one
-        // @see the av_buffersink_get_frame documentation
-        av_frame_unref(&_filteredData->getAVFrame());
+        _filteredData->clear();
 
         LOG_DEBUG("Encode")
         _outputEncoder->encodeFrame(*_transformedData, data);


### PR DESCRIPTION
Each time we use the _av_buffersink_get_frame_ function, we have to free the output AVFrame.

See the [av_buffersink_get_frame documentation](https://www.ffmpeg.org/doxygen/2.6/group__lavfi__buffersink.html#ga653228f4cbca427c654d844a5fc59cfa).