### PR TITLE
Fix memory leaks

### DIFF
--- a/app/avProcessor/avProcessor.cpp
+++ b/app/avProcessor/avProcessor.cpp
@@ -28,7 +28,7 @@ void parseConfigFile(const std::string& configFilename, avtranscoder::Transcoder
 
                 std::stringstream ss(streamId);
                 size_t streamIndex = 0;
-                char separator;
+                char separator = 'x';
                 std::vector<size_t> channelIndexArray;
                 ss >> streamIndex;
                 ss >> separator;

--- a/src/AvTranscoder/codec/AudioCodec.cpp
+++ b/src/AvTranscoder/codec/AudioCodec.cpp
@@ -1,5 +1,7 @@
 #include "AudioCodec.hpp"
 
+#include <AvTranscoder/util.hpp>
+
 #include <cmath>
 #include <cassert>
 
@@ -24,7 +26,7 @@ AudioCodec::AudioCodec(const ECodecType type, AVCodecContext& avCodecContext)
 AudioFrameDesc AudioCodec::getAudioFrameDesc() const
 {
     assert(_avCodecContext != NULL);
-    return AudioFrameDesc(_avCodecContext->sample_rate, _avCodecContext->channels, _avCodecContext->sample_fmt);
+    return AudioFrameDesc(_avCodecContext->sample_rate, _avCodecContext->channels, getSampleFormatName(_avCodecContext->sample_fmt));
 }
 
 void AudioCodec::setAudioParameters(const AudioFrameDesc& audioFrameDesc)

--- a/src/AvTranscoder/codec/ICodec.cpp
+++ b/src/AvTranscoder/codec/ICodec.cpp
@@ -49,7 +49,7 @@ ICodec::~ICodec()
     if(!_isCodecContextAllocated)
         return;
 
-    av_free(_avCodecContext);
+    avcodec_free_context(&_avCodecContext);
     _avCodecContext = NULL;
 }
 

--- a/src/AvTranscoder/codec/ICodec.cpp
+++ b/src/AvTranscoder/codec/ICodec.cpp
@@ -148,7 +148,8 @@ void ICodec::allocateContext()
     _avCodecContext = avcodec_alloc_context3(_avCodec);
     if(!_avCodecContext)
     {
-        throw std::runtime_error("Unable to allocate the codecContext and set its fields to default values");
+        LOG_ERROR("Unable to allocate the codecContext and set its fields to default values.")
+        throw std::bad_alloc();
     }
     _avCodecContext->codec = _avCodec;
 }

--- a/src/AvTranscoder/codec/VideoCodec.cpp
+++ b/src/AvTranscoder/codec/VideoCodec.cpp
@@ -1,5 +1,7 @@
 #include "VideoCodec.hpp"
 
+#include <AvTranscoder/util.hpp>
+
 #include <cmath>
 #include <cassert>
 
@@ -24,7 +26,7 @@ VideoCodec::VideoCodec(const ECodecType type, AVCodecContext& avCodecContext)
 VideoFrameDesc VideoCodec::getVideoFrameDesc() const
 {
     assert(_avCodecContext != NULL);
-    VideoFrameDesc videoFrameDesc(_avCodecContext->width, _avCodecContext->height, _avCodecContext->pix_fmt);
+    VideoFrameDesc videoFrameDesc(_avCodecContext->width, _avCodecContext->height, getPixelFormatName(_avCodecContext->pix_fmt));
     double fps = 1.0 * _avCodecContext->time_base.den / (_avCodecContext->time_base.num * _avCodecContext->ticks_per_frame);
     if(!std::isinf(fps))
         videoFrameDesc._fps = fps;

--- a/src/AvTranscoder/data/coded/CodedData.cpp
+++ b/src/AvTranscoder/data/coded/CodedData.cpp
@@ -14,7 +14,12 @@ CodedData::CodedData()
 CodedData::CodedData(const size_t dataSize)
     : _avStream(NULL)
 {
-    av_new_packet(&_packet, dataSize);
+    const int err = av_new_packet(&_packet, dataSize);
+    if(err != 0)
+    {
+        LOG_ERROR("Unable to allocate the payload of a packet and initialize its fields with default values: " << getDescriptionFromErrorCode(err))
+        throw std::bad_alloc();
+    }
 }
 
 CodedData::CodedData(const AVPacket& avPacket)

--- a/src/AvTranscoder/data/data.i
+++ b/src/AvTranscoder/data/data.i
@@ -2,12 +2,12 @@
 
 %{
 #include <AvTranscoder/data/coded/CodedData.hpp>
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/IFrame.hpp>
 #include <AvTranscoder/data/decoded/VideoFrame.hpp>
 #include <AvTranscoder/data/decoded/AudioFrame.hpp>
 %}
 
 %include <AvTranscoder/data/coded/CodedData.hpp>
-%include <AvTranscoder/data/decoded/Frame.hpp>
+%include <AvTranscoder/data/decoded/IFrame.hpp>
 %include <AvTranscoder/data/decoded/VideoFrame.hpp>
 %include <AvTranscoder/data/decoded/AudioFrame.hpp>

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -113,14 +113,14 @@ void AudioFrame::allocateData()
     if(ret < 0)
     {
         const std::string formatName = getSampleFormatName(_desc._sampleFormat);
-        std::stringstream stream;
-        stream << "Unable to allocate an audio frame of ";
-        stream << "sample rate = " << _frame->sample_rate << ", ";
-        stream << "nb channels = " << _frame->channels << ", ";
-        stream << "channel layout = " << av_get_channel_name(_frame->channels) << ", ";
-        stream << "nb samples = " << _frame->nb_samples << ", ";
-        stream << "sample format = " << (formatName.empty() ? "none" : formatName);
-        LOG_ERROR(stream.str())
+        std::stringstream msg;
+        msg << "Unable to allocate an audio frame of ";
+        msg << "sample rate = " << _frame->sample_rate << ", ";
+        msg << "nb channels = " << _frame->channels << ", ";
+        msg << "channel layout = " << av_get_channel_name(_frame->channels) << ", ";
+        msg << "nb samples = " << _frame->nb_samples << ", ";
+        msg << "sample format = " << (formatName.empty() ? "none" : formatName);
+        LOG_ERROR(msg.str())
         throw std::bad_alloc();
     }
     _dataAllocated = true;
@@ -139,9 +139,9 @@ void AudioFrame::assignBuffer(const unsigned char* ptrValue)
                                            getNbSamplesPerChannel(), getSampleFormat(), align);
     if(ret < 0)
     {
-        std::stringstream os;
-        os << "Unable to assign an audio buffer: " << getDescriptionFromErrorCode(ret);
-        throw std::runtime_error(os.str());
+        std::stringstream msg;
+        msg << "Unable to assign an audio buffer: " << getDescriptionFromErrorCode(ret);
+        throw std::runtime_error(msg.str());
     }
 }
 

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -75,7 +75,7 @@ size_t AudioFrame::getBytesPerSample() const
     return av_get_bytes_per_sample(getSampleFormat());
 }
 
-size_t AudioFrame::getSize() const
+size_t AudioFrame::getDataSize() const
 {
     if(getSampleFormat() == AV_SAMPLE_FMT_NONE)
     {

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -69,6 +69,11 @@ AudioFrame::~AudioFrame()
         freeData();
 }
 
+size_t AudioFrame::getBytesPerSample() const
+{
+    return av_get_bytes_per_sample(getSampleFormat());
+}
+
 size_t AudioFrame::getSize() const
 {
     if(getSampleFormat() == AV_SAMPLE_FMT_NONE)
@@ -77,14 +82,14 @@ size_t AudioFrame::getSize() const
         return 0;
     }
 
-    const size_t size = getNbSamplesPerChannel() * getNbChannels() * av_get_bytes_per_sample(getSampleFormat());
+    const size_t size = getNbSamplesPerChannel() * getNbChannels() * getBytesPerSample();
     if(size == 0)
     {
         std::stringstream msg;
         msg << "Unable to determine audio buffer size:" << std::endl;
         msg << "nb sample per channel = " << getNbSamplesPerChannel() << std::endl;
         msg << "channels = " << getNbChannels() << std::endl;
-        msg << "bytes per sample = " << av_get_bytes_per_sample(getSampleFormat()) << std::endl;
+        msg << "bytes per sample = " << getBytesPerSample() << std::endl;
         throw std::runtime_error(msg.str());
     }
     return size;

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -40,7 +40,7 @@ void AudioFrameDesc::setParameters(const ProfileLoader::Profile& profile)
 }
 
 AudioFrame::AudioFrame(const AudioFrameDesc& desc, const bool forceDataAllocation)
-    : Frame()
+    : IFrame()
     , _desc(desc)
 {
     // Set Frame properties

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -12,18 +12,19 @@ extern "C" {
 namespace avtranscoder
 {
 
-AudioFrameDesc::AudioFrameDesc(const size_t sampleRate, const size_t nbChannels, const AVSampleFormat sampleFormat)
-    : _sampleRate(sampleRate)
-    , _nbChannels(nbChannels)
-    , _sampleFormat(sampleFormat)
-{
-}
-
 AudioFrameDesc::AudioFrameDesc(const size_t sampleRate, const size_t nbChannels, const std::string& sampleFormatName)
     : _sampleRate(sampleRate)
     , _nbChannels(nbChannels)
     , _sampleFormat(getAVSampleFormat(sampleFormatName))
 {
+}
+
+AudioFrameDesc::AudioFrameDesc(const ProfileLoader::Profile& profile)
+    : _sampleRate(0)
+    , _nbChannels(0)
+    , _sampleFormat(AV_SAMPLE_FMT_NONE)
+{
+    setParameters(profile);
 }
 
 void AudioFrameDesc::setParameters(const ProfileLoader::Profile& profile)

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -39,7 +39,7 @@ void AudioFrameDesc::setParameters(const ProfileLoader::Profile& profile)
         _sampleFormat = getAVSampleFormat(profile.find(constants::avProfileSampleFormat)->second.c_str());
 }
 
-AudioFrame::AudioFrame(const AudioFrameDesc& desc)
+AudioFrame::AudioFrame(const AudioFrameDesc& desc, const bool forceDataAllocation)
     : Frame()
     , _desc(desc)
 {
@@ -49,6 +49,9 @@ AudioFrame::AudioFrame(const AudioFrameDesc& desc)
     av_frame_set_channel_layout(_frame, av_get_default_channel_layout(desc._nbChannels));
     _frame->format = desc._sampleFormat;
     _frame->nb_samples = desc._sampleRate / 25.; // cannot be known before calling avcodec_decode_audio4
+
+    if(forceDataAllocation)
+        allocateData();
 }
 
 std::string AudioFrame::getChannelLayoutDesc() const
@@ -87,9 +90,6 @@ size_t AudioFrame::getSize() const
 
 void AudioFrame::allocateData()
 {
-    if(_dataAllocated)
-        return;
-
     // Set Frame properties
     av_frame_set_sample_rate(_frame, _desc._sampleRate);
     av_frame_set_channels(_frame, _desc._nbChannels);

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -63,6 +63,8 @@ std::string AudioFrame::getChannelLayoutDesc() const
 
 AudioFrame::~AudioFrame()
 {
+    if(_frame->buf[0])
+        av_frame_unref(_frame);
     if(_dataAllocated)
         freeData();
 }

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -57,6 +57,11 @@ std::string AudioFrame::getChannelLayoutDesc() const
     return std::string(buf);
 }
 
+AudioFrame::~AudioFrame()
+{
+    freeAVSample();
+}
+
 size_t AudioFrame::getSize() const
 {
     if(getSampleFormat() == AV_SAMPLE_FMT_NONE)
@@ -102,6 +107,11 @@ void AudioFrame::allocateAVSample(const AudioFrameDesc& desc)
         os << "sample format = " << getSampleFormatName(desc._sampleFormat);
         throw std::runtime_error(os.str());
     }
+}
+
+void AudioFrame::freeAVSample()
+{
+    av_freep(&_frame->data[0]);
 }
 
 void AudioFrame::assign(const unsigned char value)

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -98,6 +98,9 @@ size_t AudioFrame::getDataSize() const
 
 void AudioFrame::allocateData()
 {
+    if(_dataAllocated)
+        LOG_WARN("The AudioFrame seems to already have allocated data. This could lead to memory leaks.")
+
     // Set Frame properties
     av_frame_set_sample_rate(_frame, _desc._sampleRate);
     av_frame_set_channels(_frame, _desc._nbChannels);

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -122,19 +122,7 @@ void AudioFrame::freeData()
     _dataAllocated = false;
 }
 
-void AudioFrame::assign(const unsigned char value)
-{
-    // Create the audio buffer
-    // The buffer will be freed in destructor of based class
-    const int audioSize = getSize();
-    unsigned char* audioBuffer = new unsigned char[audioSize];
-    memset(audioBuffer, value, audioSize);
-
-    // Fill the picture
-    assign(audioBuffer);
-}
-
-void AudioFrame::assign(const unsigned char* ptrValue)
+void AudioFrame::assignBuffer(const unsigned char* ptrValue)
 {
     const int align = 0;
     const int ret = av_samples_fill_arrays(_frame->data, _frame->linesize, ptrValue, getNbChannels(),

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -110,7 +110,8 @@ void AudioFrame::allocateData()
         os << "channel layout = " << av_get_channel_name(_frame->channels) << ", ";
         os << "nb samples = " << _frame->nb_samples << ", ";
         os << "sample format = " << getSampleFormatName(_desc._sampleFormat);
-        throw std::runtime_error(os.str());
+        LOG_ERROR(os.str())
+        throw std::bad_alloc();
     }
     _dataAllocated = true;
 }

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -103,7 +103,8 @@ void AudioFrame::allocateData()
     av_frame_set_channels(_frame, _desc._nbChannels);
     av_frame_set_channel_layout(_frame, av_get_default_channel_layout(_desc._nbChannels));
     _frame->format = _desc._sampleFormat;
-    _frame->nb_samples = getDefaultNbSamples();
+    if(_frame->nb_samples == 0)
+        _frame->nb_samples = getDefaultNbSamples();
 
     // Allocate data
     const int align = 0;

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -110,14 +110,15 @@ void AudioFrame::allocateData()
         av_samples_alloc(_frame->data, _frame->linesize, _frame->channels, _frame->nb_samples, _desc._sampleFormat, align);
     if(ret < 0)
     {
-        std::stringstream os;
-        os << "Unable to allocate an audio frame of ";
-        os << "sample rate = " << _frame->sample_rate << ", ";
-        os << "nb channels = " << _frame->channels << ", ";
-        os << "channel layout = " << av_get_channel_name(_frame->channels) << ", ";
-        os << "nb samples = " << _frame->nb_samples << ", ";
-        os << "sample format = " << getSampleFormatName(_desc._sampleFormat);
-        LOG_ERROR(os.str())
+        const std::string formatName = getSampleFormatName(_desc._sampleFormat);
+        std::stringstream stream;
+        stream << "Unable to allocate an audio frame of ";
+        stream << "sample rate = " << _frame->sample_rate << ", ";
+        stream << "nb channels = " << _frame->channels << ", ";
+        stream << "channel layout = " << av_get_channel_name(_frame->channels) << ", ";
+        stream << "nb samples = " << _frame->nb_samples << ", ";
+        stream << "sample format = " << (formatName.empty() ? "none" : formatName);
+        LOG_ERROR(stream.str())
         throw std::bad_alloc();
     }
     _dataAllocated = true;

--- a/src/AvTranscoder/data/decoded/AudioFrame.cpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.cpp
@@ -49,7 +49,7 @@ AudioFrame::AudioFrame(const AudioFrameDesc& desc, const bool forceDataAllocatio
     av_frame_set_channels(_frame, desc._nbChannels);
     av_frame_set_channel_layout(_frame, av_get_default_channel_layout(desc._nbChannels));
     _frame->format = desc._sampleFormat;
-    _frame->nb_samples = desc._sampleRate / 25.; // cannot be known before calling avcodec_decode_audio4
+    _frame->nb_samples = getDefaultNbSamples();
 
     if(forceDataAllocation)
         allocateData();
@@ -103,7 +103,7 @@ void AudioFrame::allocateData()
     av_frame_set_channels(_frame, _desc._nbChannels);
     av_frame_set_channel_layout(_frame, av_get_default_channel_layout(_desc._nbChannels));
     _frame->format = _desc._sampleFormat;
-    _frame->nb_samples = _desc._sampleRate / 25.; // cannot be known before calling avcodec_decode_audio4
+    _frame->nb_samples = getDefaultNbSamples();
 
     // Allocate data
     const int align = 0;
@@ -143,4 +143,10 @@ void AudioFrame::assignBuffer(const unsigned char* ptrValue)
         throw std::runtime_error(os.str());
     }
 }
+
+size_t AudioFrame::getDefaultNbSamples() const
+{
+    return _desc._sampleRate / 25.;
+}
+
 }

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -49,7 +49,7 @@ public:
      */
     void allocateData();
     void freeData();
-    size_t getSize() const;
+    size_t getDataSize() const;
 
     size_t getSampleRate() const { return av_frame_get_sample_rate(_frame); }
     size_t getNbChannels() const { return av_frame_get_channels(_frame); }

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -36,7 +36,7 @@ public:
 class AvExport AudioFrame : public Frame
 {
 public:
-    AudioFrame(const AudioFrameDesc& desc);
+    AudioFrame(const AudioFrameDesc& desc, const bool forceDataAllocation = true);
     ~AudioFrame();
 
     /**

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -35,6 +35,10 @@ public:
  */
 class AvExport AudioFrame : public IFrame
 {
+private:
+    AudioFrame(const AudioFrame& otherFrame);
+    AudioFrame& operator=(const AudioFrame& otherFrame);
+
 public:
     AudioFrame(const AudioFrameDesc& desc, const bool forceDataAllocation = true);
     ~AudioFrame();

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -41,6 +41,7 @@ public:
      */
     AudioFrame(const AudioFrameDesc& ref);
     AudioFrame(const Frame& otherFrame);
+    ~AudioFrame();
 
     size_t getSampleRate() const { return av_frame_get_sample_rate(_frame); }
     size_t getNbChannels() const { return av_frame_get_channels(_frame); }
@@ -69,8 +70,15 @@ public:
 private:
     /**
      * @brief Allocate the audio buffer of the frame.
+     * @warning The allocated data should be freed by the caller.
+     * @see freeAVSample
      */
     void allocateAVSample(const AudioFrameDesc& ref);
+
+    /**
+     * @brief Free the audio buffer of the frame.
+     */
+    void freeAVSample();
 
     /**
      * @note To allocate new audio buffer if needed.

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -72,7 +72,7 @@ private:
      * @brief The number of samples of a frame cannot be known before calling avcodec_decode_audio4,
      * and can be variable in a same stream. Because we need to allocate some frames without knowing this parameter,
      * we access here a default number of samples.
-     * @note This value depends on the sample rate (excample: 1920 samples at 48kHz).
+     * @note This value depends on the sample rate (example: 1920 samples at 48kHz).
      * @return the number of samples of our default AudioFrame.
      * @see setNbSamplesPerChannel
      */

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -70,6 +70,14 @@ public:
      * @see getSize
      */
     void assign(const unsigned char* ptrValue);
+
+private:
+    /**
+     * @brief Description of the frame to allocate.
+     * @warning This description could be different from the current frame (a decoder could have reseted it).
+     * We need to keep this description to allocate again the frame even if it was reseted.
+     */
+    const AudioFrameDesc _desc;
 };
 }
 

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -69,6 +69,17 @@ public:
 
 private:
     /**
+     * @brief The number of samples of a frame cannot be known before calling avcodec_decode_audio4,
+     * and can be variable in a same stream. Because we need to allocate some frames without knowing this parameter,
+     * we access here a default number of samples.
+     * @note This value depends on the sample rate (excample: 1920 samples at 48kHz).
+     * @return the number of samples of our default AudioFrame.
+     * @see setNbSamplesPerChannel
+     */
+    size_t getDefaultNbSamples() const;
+
+private:
+    /**
      * @brief Description of the frame to allocate.
      * @warning This description could be different from the current frame (a decoder could have reseted it).
      * We need to keep this description to allocate again the frame even if it was reseted.

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -1,7 +1,7 @@
 #ifndef _AV_TRANSCODER_FRAME_AUDIO_FRAME_HPP_
 #define _AV_TRANSCODER_FRAME_AUDIO_FRAME_HPP_
 
-#include "Frame.hpp"
+#include "IFrame.hpp"
 #include <AvTranscoder/profile/ProfileLoader.hpp>
 
 namespace avtranscoder
@@ -33,7 +33,7 @@ public:
 /**
  * @brief This class describes decoded audio data.
  */
-class AvExport AudioFrame : public Frame
+class AvExport AudioFrame : public IFrame
 {
 public:
     AudioFrame(const AudioFrameDesc& desc, const bool forceDataAllocation = true);

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -49,6 +49,7 @@ public:
      */
     void allocateData();
     void freeData();
+    size_t getSize() const;
 
     size_t getSampleRate() const { return av_frame_get_sample_rate(_frame); }
     size_t getNbChannels() const { return av_frame_get_channels(_frame); }
@@ -57,8 +58,6 @@ public:
     AVSampleFormat getSampleFormat() const { return static_cast<AVSampleFormat>(_frame->format); }
     size_t getBytesPerSample() const;  ///< 0 if unknown sample format
     size_t getNbSamplesPerChannel() const { return _frame->nb_samples; }
-
-    size_t getSize() const;
 
     /**
      * @brief This methods dynamically updates the size that the data buffer would occupy if allocated.

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -58,17 +58,7 @@ public:
 
     void setNbSamplesPerChannel(const size_t nbSamples) { _frame->nb_samples = nbSamples; }
 
-    /**
-     * @brief Assign the given value to all the data of the audio frame.
-     */
-    void assign(const unsigned char value);
-
-    /**
-     * @brief Assign the given ptr of data to the data of the audio frame.
-     * @warning the given ptr should have the size of the audio frame..
-     * @see getSize
-     */
-    void assign(const unsigned char* ptrValue);
+    void assignBuffer(const unsigned char* ptrValue);
 
 private:
     /**

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -53,7 +53,6 @@ public:
     std::string getChannelLayoutDesc() const; ///< Get a description of a channel layout (example: '5.1').
     AVSampleFormat getSampleFormat() const { return static_cast<AVSampleFormat>(_frame->format); }
     size_t getNbSamplesPerChannel() const { return _frame->nb_samples; }
-    AudioFrameDesc desc() const { return AudioFrameDesc(getSampleRate(), getNbChannels(), getSampleFormat()); }
 
     size_t getSize() const;
 

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -52,6 +52,7 @@ public:
     size_t getChannelLayout() const { return av_frame_get_channel_layout(_frame); }
     std::string getChannelLayoutDesc() const; ///< Get a description of a channel layout (example: '5.1').
     AVSampleFormat getSampleFormat() const { return static_cast<AVSampleFormat>(_frame->format); }
+    size_t getBytesPerSample() const;  ///< 0 if unknown sample format
     size_t getNbSamplesPerChannel() const { return _frame->nb_samples; }
 
     size_t getSize() const;

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -14,9 +14,8 @@ namespace avtranscoder
 struct AvExport AudioFrameDesc
 {
 public:
-    AudioFrameDesc(const size_t sampleRate = 0, const size_t channels = 0,
-                   const AVSampleFormat sampleFormat = AV_SAMPLE_FMT_NONE);
     AudioFrameDesc(const size_t sampleRate, const size_t channels, const std::string& sampleFormatName);
+    AudioFrameDesc(const ProfileLoader::Profile& profile);
 
     /**
      * @brief Set the attributes from the given profile.

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -56,6 +56,10 @@ public:
 
     size_t getSize() const;
 
+    /**
+     * @brief This methods dynamically updates the size that the data buffer would occupy if allocated.
+     * @warning If the data buffer is already allocated, this could lead to memory leaks or seg fault.
+     */
     void setNbSamplesPerChannel(const size_t nbSamples) { _frame->nb_samples = nbSamples; }
 
     void assignBuffer(const unsigned char* ptrValue);

--- a/src/AvTranscoder/data/decoded/AudioFrame.hpp
+++ b/src/AvTranscoder/data/decoded/AudioFrame.hpp
@@ -36,12 +36,16 @@ public:
 class AvExport AudioFrame : public Frame
 {
 public:
-    /**
-     * @note Allocated data will be initialized to silence.
-     */
-    AudioFrame(const AudioFrameDesc& ref);
-    AudioFrame(const Frame& otherFrame);
+    AudioFrame(const AudioFrameDesc& desc);
     ~AudioFrame();
+
+    /**
+     * @brief Allocated data will be initialized to silence.
+     * @warning The allocated data should be freed by the caller.
+     * @see freeData
+     */
+    void allocateData();
+    void freeData();
 
     size_t getSampleRate() const { return av_frame_get_sample_rate(_frame); }
     size_t getNbChannels() const { return av_frame_get_channels(_frame); }
@@ -51,7 +55,7 @@ public:
     size_t getNbSamplesPerChannel() const { return _frame->nb_samples; }
     AudioFrameDesc desc() const { return AudioFrameDesc(getSampleRate(), getNbChannels(), getSampleFormat()); }
 
-    size_t getSize() const; ///< in bytes
+    size_t getSize() const;
 
     void setNbSamplesPerChannel(const size_t nbSamples) { _frame->nb_samples = nbSamples; }
 
@@ -66,25 +70,6 @@ public:
      * @see getSize
      */
     void assign(const unsigned char* ptrValue);
-
-private:
-    /**
-     * @brief Allocate the audio buffer of the frame.
-     * @warning The allocated data should be freed by the caller.
-     * @see freeAVSample
-     */
-    void allocateAVSample(const AudioFrameDesc& ref);
-
-    /**
-     * @brief Free the audio buffer of the frame.
-     */
-    void freeAVSample();
-
-    /**
-     * @note To allocate new audio buffer if needed.
-     * @see allocateAVSample
-     */
-    friend class AudioGenerator;
 };
 }
 

--- a/src/AvTranscoder/data/decoded/Frame.cpp
+++ b/src/AvTranscoder/data/decoded/Frame.cpp
@@ -14,22 +14,16 @@ Frame::Frame()
 Frame::Frame(const Frame& otherFrame)
     : _frame(NULL)
 {
-    // allocate frame
     allocateAVFrame();
-    // check if the frame could be a valid video/audio frame
-    if(otherFrame.getAVFrame().format == -1)
-        return;
-    // reference the other frame
-    refFrame(otherFrame);
+    copyProperties(otherFrame);
+    copyData(otherFrame);
 }
 
 void Frame::operator=(const Frame& otherFrame)
 {
-    // check if the frame could be a valid video/audio frame
-    if(otherFrame.getAVFrame().format == -1)
-        return;
-    // reference the other frame
-    refFrame(otherFrame);
+    allocateAVFrame();
+    copyProperties(otherFrame);
+    copyData(otherFrame);
 }
 
 Frame::~Frame()
@@ -54,25 +48,6 @@ void Frame::copyData(const Frame& frameToRef)
 void Frame::copyProperties(const Frame& otherFrame)
 {
     av_frame_copy_props(_frame, &otherFrame.getAVFrame());
-}
-
-bool Frame::isRefCounted() const
-{
-    return _frame->buf[0];
-}
-
-void Frame::refFrame(const Frame& otherFrame)
-{
-    const int ret = av_frame_ref(_frame, &otherFrame.getAVFrame());
-    if(ret < 0)
-    {
-        throw std::ios_base::failure("Unable to reference other frame: " + getDescriptionFromErrorCode(ret));
-    }
-}
-
-void Frame::unrefFrame()
-{
-    av_frame_unref(_frame);
 }
 
 void Frame::allocateAVFrame()

--- a/src/AvTranscoder/data/decoded/Frame.cpp
+++ b/src/AvTranscoder/data/decoded/Frame.cpp
@@ -82,7 +82,7 @@ void Frame::refFrame(const Frame& otherFrame)
     }
 }
 
-void Frame::clear()
+void Frame::unrefFrame()
 {
     av_frame_unref(_frame);
 }

--- a/src/AvTranscoder/data/decoded/Frame.cpp
+++ b/src/AvTranscoder/data/decoded/Frame.cpp
@@ -68,6 +68,11 @@ void Frame::copyProperties(const Frame& otherFrame)
     av_frame_copy_props(_frame, &otherFrame.getAVFrame());
 }
 
+bool Frame::isRefCounted() const
+{
+    return _frame->buf[0];
+}
+
 void Frame::refFrame(const Frame& otherFrame)
 {
     const int ret = av_frame_ref(_frame, &otherFrame.getAVFrame());

--- a/src/AvTranscoder/data/decoded/Frame.cpp
+++ b/src/AvTranscoder/data/decoded/Frame.cpp
@@ -7,33 +7,14 @@ namespace avtranscoder
 
 Frame::Frame()
     : _frame(NULL)
+    , _dataAllocated(false)
 {
     allocateAVFrame();
-}
-
-Frame::Frame(const Frame& otherFrame)
-    : _frame(NULL)
-{
-    allocateAVFrame();
-    copyProperties(otherFrame);
-    copyData(otherFrame);
-}
-
-void Frame::operator=(const Frame& otherFrame)
-{
-    allocateAVFrame();
-    copyProperties(otherFrame);
-    copyData(otherFrame);
 }
 
 Frame::~Frame()
 {
     freeAVFrame();
-}
-
-int Frame::getEncodedSize() const
-{
-    return av_frame_get_pkt_size(_frame);
 }
 
 void Frame::copyData(const Frame& frameToRef)

--- a/src/AvTranscoder/data/decoded/Frame.cpp
+++ b/src/AvTranscoder/data/decoded/Frame.cpp
@@ -40,7 +40,8 @@ void Frame::allocateAVFrame()
 #endif
     if(_frame == NULL)
     {
-        throw std::runtime_error("Unable to allocate an empty Frame.");
+        LOG_ERROR("Unable to allocate an empty Frame.")
+        throw std::bad_alloc();
     }
 }
 

--- a/src/AvTranscoder/data/decoded/Frame.cpp
+++ b/src/AvTranscoder/data/decoded/Frame.cpp
@@ -34,19 +34,7 @@ void Frame::operator=(const Frame& otherFrame)
 
 Frame::~Frame()
 {
-    if(_frame != NULL)
-    {
-#if LIBAVCODEC_VERSION_MAJOR > 54
-        av_frame_free(&_frame);
-#else
-#if LIBAVCODEC_VERSION_MAJOR > 53
-        avcodec_free_frame(&_frame);
-#else
-        av_free(_frame);
-#endif
-#endif
-        _frame = NULL;
-    }
+    freeAVFrame();
 }
 
 int Frame::getEncodedSize() const
@@ -97,6 +85,23 @@ void Frame::allocateAVFrame()
     if(_frame == NULL)
     {
         throw std::runtime_error("Unable to allocate an empty Frame.");
+    }
+}
+
+void Frame::freeAVFrame()
+{
+    if(_frame != NULL)
+    {
+#if LIBAVCODEC_VERSION_MAJOR > 54
+        av_frame_free(&_frame);
+#else
+#if LIBAVCODEC_VERSION_MAJOR > 53
+        avcodec_free_frame(&_frame);
+#else
+        av_free(_frame);
+#endif
+#endif
+        _frame = NULL;
     }
 }
 

--- a/src/AvTranscoder/data/decoded/Frame.hpp
+++ b/src/AvTranscoder/data/decoded/Frame.hpp
@@ -23,7 +23,7 @@ public:
     Frame();
 
     //@{
-    // @brief Copy properties and reference data of the other frame.
+    // @brief Allocate a new frame that references the same data as the given frame.
     Frame(const Frame& otherFrame);
     void operator=(const Frame& otherFrame);
     //@}
@@ -63,23 +63,6 @@ public:
      * @brief Copy all the fields that do not affect the data layout in the buffers.
      */
     void copyProperties(const Frame& otherFrame);
-
-    /**
-     * @brief If the data buffer of the frame refers to data allocated by an other frame.
-     */
-    bool isRefCounted() const;
-
-    /**
-     * @brief Copy frame properties and create a new reference to data of the given frame.
-     * @warning This method allocates new data that will be freed by calling clear method or the destructor of the referenced frame.
-     * @see clear
-     */
-    void refFrame(const Frame& otherFrame);
-
-    /**
-     * @brief Unreference all the buffers referenced by frame and reset the frame fields.
-     */
-    void unrefFrame();
 
     /**
      * @return If it corresponds to a valid audio frame.

--- a/src/AvTranscoder/data/decoded/Frame.hpp
+++ b/src/AvTranscoder/data/decoded/Frame.hpp
@@ -79,7 +79,7 @@ public:
     /**
      * @brief Unreference all the buffers referenced by frame and reset the frame fields.
      */
-    void clear();
+    void unrefFrame();
 
     /**
      * @return If it corresponds to a valid audio frame.

--- a/src/AvTranscoder/data/decoded/Frame.hpp
+++ b/src/AvTranscoder/data/decoded/Frame.hpp
@@ -101,6 +101,7 @@ public:
 
 private:
     void allocateAVFrame();
+    void freeAVFrame();
 
 protected:
     AVFrame* _frame;

--- a/src/AvTranscoder/data/decoded/Frame.hpp
+++ b/src/AvTranscoder/data/decoded/Frame.hpp
@@ -52,8 +52,10 @@ public:
 
     /**
      * @brief Copy the data of the given Frame.
-     * @note This function does not allocate anything: the current frame must be already initialized and
+     * This function does not allocate anything: the current frame must be already initialized and
      * allocated with the same parameters as the given frame, to be ready for memcpy instructions.
+     * @note It copies the frame data (i.e. the contents of the data / extended data arrays), not any other properties.
+     * @see copyProperties
      */
     void copyData(const Frame& frameToRef);
 
@@ -61,6 +63,11 @@ public:
      * @brief Copy all the fields that do not affect the data layout in the buffers.
      */
     void copyProperties(const Frame& otherFrame);
+
+    /**
+     * @brief If the data buffer of the frame refers to data allocated by an other frame.
+     */
+    bool isRefCounted() const;
 
     /**
      * @brief Copy frame properties and create a new reference to data of the given frame.

--- a/src/AvTranscoder/data/decoded/IFrame.cpp
+++ b/src/AvTranscoder/data/decoded/IFrame.cpp
@@ -1,23 +1,23 @@
-#include "Frame.hpp"
+#include "IFrame.hpp"
 
 #include <stdexcept>
 
 namespace avtranscoder
 {
 
-Frame::Frame()
+IFrame::IFrame()
     : _frame(NULL)
     , _dataAllocated(false)
 {
     allocateAVFrame();
 }
 
-Frame::~Frame()
+IFrame::~IFrame()
 {
     freeAVFrame();
 }
 
-void Frame::copyData(const Frame& frameToRef)
+void IFrame::copyData(const IFrame& frameToRef)
 {
     const int ret = av_frame_copy(_frame, &frameToRef.getAVFrame());
     if(ret < 0)
@@ -26,12 +26,12 @@ void Frame::copyData(const Frame& frameToRef)
     }
 }
 
-void Frame::copyProperties(const Frame& otherFrame)
+void IFrame::copyProperties(const IFrame& otherFrame)
 {
     av_frame_copy_props(_frame, &otherFrame.getAVFrame());
 }
 
-void Frame::allocateAVFrame()
+void IFrame::allocateAVFrame()
 {
 #if LIBAVCODEC_VERSION_MAJOR > 54
     _frame = av_frame_alloc();
@@ -45,7 +45,7 @@ void Frame::allocateAVFrame()
     }
 }
 
-void Frame::freeAVFrame()
+void IFrame::freeAVFrame()
 {
     if(_frame != NULL)
     {
@@ -62,14 +62,14 @@ void Frame::freeAVFrame()
     }
 }
 
-bool Frame::isAudioFrame() const
+bool IFrame::isAudioFrame() const
 {
     if(_frame->sample_rate && _frame->channels && _frame->channel_layout && _frame->format != -1)
         return true;
     return false;
 }
 
-bool Frame::isVideoFrame() const
+bool IFrame::isVideoFrame() const
 {
     if(_frame->width && _frame->height && _frame->format != -1)
         return true;

--- a/src/AvTranscoder/data/decoded/IFrame.cpp
+++ b/src/AvTranscoder/data/decoded/IFrame.cpp
@@ -64,13 +64,19 @@ void IFrame::freeAVFrame()
 
 void IFrame::assignValue(const unsigned char value)
 {
+    // Free the existing data
+    freeData();
+
     // Create the buffer
     const int bufferSize = getSize();
-    unsigned char* dataBuffer = new unsigned char[bufferSize];
+    unsigned char* dataBuffer = static_cast<unsigned char*>(malloc(bufferSize * sizeof(unsigned char)));
     memset(dataBuffer, value, bufferSize);
 
     // Fill the frame
     assignBuffer(dataBuffer);
+
+    // Prepare to free the data
+    _dataAllocated = true;
 }
 
 bool IFrame::isAudioFrame() const

--- a/src/AvTranscoder/data/decoded/IFrame.cpp
+++ b/src/AvTranscoder/data/decoded/IFrame.cpp
@@ -62,6 +62,17 @@ void IFrame::freeAVFrame()
     }
 }
 
+void IFrame::assignValue(const unsigned char value)
+{
+    // Create the buffer
+    const int bufferSize = getSize();
+    unsigned char* dataBuffer = new unsigned char[bufferSize];
+    memset(dataBuffer, value, bufferSize);
+
+    // Fill the frame
+    assignBuffer(dataBuffer);
+}
+
 bool IFrame::isAudioFrame() const
 {
     if(_frame->sample_rate && _frame->channels && _frame->channel_layout && _frame->format != -1)

--- a/src/AvTranscoder/data/decoded/IFrame.cpp
+++ b/src/AvTranscoder/data/decoded/IFrame.cpp
@@ -68,7 +68,7 @@ void IFrame::assignValue(const unsigned char value)
     freeData();
 
     // Create the buffer
-    const int bufferSize = getSize();
+    const int bufferSize = getDataSize();
     unsigned char* dataBuffer = static_cast<unsigned char*>(malloc(bufferSize * sizeof(unsigned char)));
     memset(dataBuffer, value, bufferSize);
 

--- a/src/AvTranscoder/data/decoded/IFrame.hpp
+++ b/src/AvTranscoder/data/decoded/IFrame.hpp
@@ -46,6 +46,18 @@ public:
     virtual size_t getSize() const = 0;
 
     /**
+     * @brief Assign the given ptr of data to the data of the frame.
+     * @warning the given ptr should have the size of the frame..
+     * @see getSize
+     */
+    virtual void assignBuffer(const unsigned char* ptrValue) = 0;
+
+    /**
+     * @brief Assign the given value to all the data of the frame.
+     */
+    void assignValue(const unsigned char value);
+
+    /**
      * @brief Get all the data of the frame.
      */
     unsigned char** getData() { return _frame->data; }

--- a/src/AvTranscoder/data/decoded/IFrame.hpp
+++ b/src/AvTranscoder/data/decoded/IFrame.hpp
@@ -16,7 +16,7 @@ namespace avtranscoder
  * @see VideoFrame
  * @see AudioFrame
  */
-class AvExport Frame
+class AvExport IFrame
 {
 public:
     /**
@@ -25,9 +25,9 @@ public:
      * Depending on the case, we could manipulate frame with data allocated elsewhere.
      * For example, an empty frame is given to a decoder, which is responsible to allocate and free the data buffers.
      */
-    Frame();
+    IFrame();
 
-    virtual ~Frame();
+    virtual ~IFrame();
 
     /**
      * @brief Allocate the buffer of the frame.
@@ -66,13 +66,13 @@ public:
      * @note It copies the frame data (i.e. the contents of the data / extended data arrays), not any other properties.
      * @see copyProperties
      */
-    void copyData(const Frame& frameToRef);
+    void copyData(const IFrame& frameToRef);
 
     /**
      * @brief Copy all the fields that do not affect the data layout in the buffers.
      * @warning The info checked when copying data of an other frame (width/height, channels...) are not copied.
      */
-    void copyProperties(const Frame& otherFrame);
+    void copyProperties(const IFrame& otherFrame);
 
     /**
      * @return If it corresponds to a valid audio frame.

--- a/src/AvTranscoder/data/decoded/IFrame.hpp
+++ b/src/AvTranscoder/data/decoded/IFrame.hpp
@@ -18,6 +18,10 @@ namespace avtranscoder
  */
 class AvExport IFrame
 {
+private:
+    IFrame(const IFrame& otherFrame);
+    IFrame& operator=(const IFrame& otherFrame);
+
 public:
     /**
      * @brief Allocate an empty frame.

--- a/src/AvTranscoder/data/decoded/IFrame.hpp
+++ b/src/AvTranscoder/data/decoded/IFrame.hpp
@@ -98,6 +98,11 @@ public:
      */
     bool isVideoFrame() const;
 
+    /**
+     * @return If the data buffer is allocated and hold by the frame.
+     */
+    bool isDataAllocated() const { return _dataAllocated; }
+
 #ifndef SWIG
     AVFrame& getAVFrame() { return *_frame; }
     const AVFrame& getAVFrame() const { return *_frame; }

--- a/src/AvTranscoder/data/decoded/IFrame.hpp
+++ b/src/AvTranscoder/data/decoded/IFrame.hpp
@@ -47,7 +47,7 @@ public:
      * @brief Get the size in bytes that a video/audio buffer of the given frame properties would occupy if allocated.
      * @warning This methods does not guarantee that the buffer is actually allocated.
      */
-    virtual size_t getSize() const = 0;
+    virtual size_t getDataSize() const = 0;
 
     /**
      * @brief Assign the given ptr of data to the data of the frame.

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -59,6 +59,8 @@ VideoFrame::VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocatio
 
 VideoFrame::~VideoFrame()
 {
+    if(_frame->buf[0])
+        av_frame_unref(_frame);
     if(_dataAllocated)
         freeData();
 }

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -77,7 +77,7 @@ size_t VideoFrame::getSize() const
 
     const size_t size = avpicture_get_size(getPixelFormat(), getWidth(), getHeight());
     if(size == 0)
-        throw std::runtime_error("unable to determine image buffer size");
+        throw std::runtime_error("Unable to determine image buffer size: " + getDescriptionFromErrorCode(size));
     return size;
 }
 

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -93,7 +93,8 @@ void VideoFrame::allocateData()
         os << "width = " << _frame->width << ", ";
         os << "height = " << _frame->height << ", ";
         os << "pixel format = " << getPixelFormatName(_desc._pixelFormat);
-        throw std::runtime_error(os.str());
+        LOG_ERROR(os.str())
+        throw std::bad_alloc();
     }
     _dataAllocated = true;
 }

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -13,14 +13,6 @@ extern "C" {
 namespace avtranscoder
 {
 
-VideoFrameDesc::VideoFrameDesc(const size_t width, const size_t height, const AVPixelFormat pixelFormat)
-    : _width(width)
-    , _height(height)
-    , _pixelFormat(pixelFormat)
-    , _fps(1.0)
-{
-}
-
 VideoFrameDesc::VideoFrameDesc(const size_t width, const size_t height, const std::string& pixelFormatName)
     : _width(width)
     , _height(height)
@@ -28,6 +20,16 @@ VideoFrameDesc::VideoFrameDesc(const size_t width, const size_t height, const st
     , _fps(1.0)
 {
 }
+
+VideoFrameDesc::VideoFrameDesc(const ProfileLoader::Profile& profile)
+    : _width(0)
+    , _height(0)
+    , _pixelFormat(AV_PIX_FMT_NONE)
+    , _fps(1.0)
+{
+    setParameters(profile);
+}
+
 
 void VideoFrameDesc::setParameters(const ProfileLoader::Profile& profile)
 {

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -45,13 +45,16 @@ void VideoFrameDesc::setParameters(const ProfileLoader::Profile& profile)
         _fps = atof(profile.find(constants::avProfileFrameRate)->second.c_str());
 }
 
-VideoFrame::VideoFrame(const VideoFrameDesc& desc)
+VideoFrame::VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocation)
     : Frame()
     , _desc(desc)
 {
     _frame->width = desc._width;
     _frame->height = desc._height;
     _frame->format = desc._pixelFormat;
+
+    if(forceDataAllocation)
+        allocateData();
 }
 
 VideoFrame::~VideoFrame()
@@ -76,9 +79,6 @@ size_t VideoFrame::getSize() const
 
 void VideoFrame::allocateData()
 {
-    if(_dataAllocated)
-        return;
-
     // Set Frame properties
     _frame->width = _desc._width;
     _frame->height = _desc._height;

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -105,19 +105,7 @@ void VideoFrame::freeData()
     _dataAllocated = false;
 }
 
-void VideoFrame::assign(const unsigned char value)
-{
-    // Create the image buffer
-    // The buffer will be freed in destructor of based class
-    const int imageSize = getSize();
-    unsigned char* imageBuffer = new unsigned char[imageSize];
-    memset(imageBuffer, value, imageSize);
-
-    // Fill the picture
-    assign(imageBuffer);
-}
-
-void VideoFrame::assign(const unsigned char* ptrValue)
+void VideoFrame::assignBuffer(const unsigned char* ptrValue)
 {
     const int ret =
         avpicture_fill(reinterpret_cast<AVPicture*>(_frame), ptrValue, getPixelFormat(), getWidth(), getHeight());

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -67,7 +67,7 @@ VideoFrame::~VideoFrame()
         freeData();
 }
 
-size_t VideoFrame::getSize() const
+size_t VideoFrame::getDataSize() const
 {
     if(getPixelFormat() == AV_PIX_FMT_NONE)
     {
@@ -117,7 +117,7 @@ void VideoFrame::assignBuffer(const unsigned char* ptrValue)
     if(ret < 0)
     {
         std::stringstream msg;
-        msg << "Unable to assign an image buffer of " << getSize() << " bytes: " << getDescriptionFromErrorCode(ret);
+        msg << "Unable to assign an image buffer of " << getDataSize() << " bytes: " << getDescriptionFromErrorCode(ret);
         throw std::runtime_error(msg.str());
     }
 }

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -47,6 +47,7 @@ void VideoFrameDesc::setParameters(const ProfileLoader::Profile& profile)
 
 VideoFrame::VideoFrame(const VideoFrameDesc& desc)
     : Frame()
+    , _desc(desc)
 {
     _frame->width = desc._width;
     _frame->height = desc._height;
@@ -78,15 +79,20 @@ void VideoFrame::allocateData()
     if(_dataAllocated)
         return;
 
-    const AVPixelFormat format = static_cast<AVPixelFormat>(_frame->format);
-    const int ret = avpicture_alloc(reinterpret_cast<AVPicture*>(_frame), format, _frame->width, _frame->height);
+    // Set Frame properties
+    _frame->width = _desc._width;
+    _frame->height = _desc._height;
+    _frame->format = _desc._pixelFormat;
+
+    // Allocate data
+    const int ret = avpicture_alloc(reinterpret_cast<AVPicture*>(_frame), _desc._pixelFormat, _desc._width, _desc._height);
     if(ret < 0)
     {
         std::stringstream os;
         os << "Unable to allocate an image frame of ";
         os << "width = " << _frame->width << ", ";
         os << "height = " << _frame->height << ", ";
-        os << "pixel format = " << getPixelFormatName(format);
+        os << "pixel format = " << getPixelFormatName(_desc._pixelFormat);
         throw std::runtime_error(os.str());
     }
     _dataAllocated = true;

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -83,6 +83,9 @@ size_t VideoFrame::getDataSize() const
 
 void VideoFrame::allocateData()
 {
+    if(_dataAllocated)
+        LOG_WARN("The VideoFrame seems to already have allocated data. This could lead to memory leaks.")
+
     // Set Frame properties
     _frame->width = _desc._width;
     _frame->height = _desc._height;

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -93,12 +93,12 @@ void VideoFrame::allocateData()
     if(ret < 0)
     {
         const std::string formatName = getPixelFormatName(_desc._pixelFormat);
-        std::stringstream stream;
-        stream << "Unable to allocate an image frame of ";
-        stream << "width = " << _frame->width << ", ";
-        stream << "height = " << _frame->height << ", ";
-        stream << "pixel format = " << (formatName.empty() ? "none" : formatName);
-        LOG_ERROR(stream.str())
+        std::stringstream msg;
+        msg << "Unable to allocate an image frame of ";
+        msg << "width = " << _frame->width << ", ";
+        msg << "height = " << _frame->height << ", ";
+        msg << "pixel format = " << (formatName.empty() ? "none" : formatName);
+        LOG_ERROR(msg.str())
         throw std::bad_alloc();
     }
     _dataAllocated = true;
@@ -116,9 +116,9 @@ void VideoFrame::assignBuffer(const unsigned char* ptrValue)
         avpicture_fill(reinterpret_cast<AVPicture*>(_frame), ptrValue, getPixelFormat(), getWidth(), getHeight());
     if(ret < 0)
     {
-        std::stringstream os;
-        os << "Unable to assign an image buffer of " << getSize() << " bytes: " << getDescriptionFromErrorCode(ret);
-        throw std::runtime_error(os.str());
+        std::stringstream msg;
+        msg << "Unable to assign an image buffer of " << getSize() << " bytes: " << getDescriptionFromErrorCode(ret);
+        throw std::runtime_error(msg.str());
     }
 }
 }

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -46,7 +46,7 @@ void VideoFrameDesc::setParameters(const ProfileLoader::Profile& profile)
 }
 
 VideoFrame::VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocation)
-    : Frame()
+    : IFrame()
     , _desc(desc)
 {
     _frame->width = desc._width;

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -56,6 +56,11 @@ VideoFrame::VideoFrame(const Frame& otherFrame)
 {
 }
 
+VideoFrame::~VideoFrame()
+{
+    freeAVPicture();
+}
+
 size_t VideoFrame::getSize() const
 {
     if(getPixelFormat() == AV_PIX_FMT_NONE)
@@ -85,6 +90,11 @@ void VideoFrame::allocateAVPicture(const VideoFrameDesc& desc)
     _frame->width = desc._width;
     _frame->height = desc._height;
     _frame->format = desc._pixelFormat;
+}
+
+void VideoFrame::freeAVPicture()
+{
+    avpicture_free(reinterpret_cast<AVPicture*>(_frame));
 }
 
 void VideoFrame::assign(const unsigned char value)

--- a/src/AvTranscoder/data/decoded/VideoFrame.cpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.cpp
@@ -90,12 +90,13 @@ void VideoFrame::allocateData()
     const int ret = avpicture_alloc(reinterpret_cast<AVPicture*>(_frame), _desc._pixelFormat, _desc._width, _desc._height);
     if(ret < 0)
     {
-        std::stringstream os;
-        os << "Unable to allocate an image frame of ";
-        os << "width = " << _frame->width << ", ";
-        os << "height = " << _frame->height << ", ";
-        os << "pixel format = " << getPixelFormatName(_desc._pixelFormat);
-        LOG_ERROR(os.str())
+        const std::string formatName = getPixelFormatName(_desc._pixelFormat);
+        std::stringstream stream;
+        stream << "Unable to allocate an image frame of ";
+        stream << "width = " << _frame->width << ", ";
+        stream << "height = " << _frame->height << ", ";
+        stream << "pixel format = " << (formatName.empty() ? "none" : formatName);
+        LOG_ERROR(stream.str())
         throw std::bad_alloc();
     }
     _dataAllocated = true;

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -1,7 +1,7 @@
 #ifndef _AV_TRANSCODER_FRAME_VIDEO_FRAME_HPP_
 #define _AV_TRANSCODER_FRAME_VIDEO_FRAME_HPP_
 
-#include "Frame.hpp"
+#include "IFrame.hpp"
 #include <AvTranscoder/profile/ProfileLoader.hpp>
 
 extern "C" {
@@ -40,7 +40,7 @@ public:
 /**
  * @brief This class describes decoded video data.
  */
-class AvExport VideoFrame : public Frame
+class AvExport VideoFrame : public IFrame
 {
 public:
     VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocation = true);

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -60,17 +60,7 @@ public:
 
     size_t getSize() const;
 
-    /**
-     * @brief Assign the given value to all the data of the picture.
-     */
-    void assign(const unsigned char value);
-
-    /**
-     * @brief Assign the given ptr of data to the data of the picture.
-     * @warning the given ptr should have the size of the picture.
-     * @see getSize
-     */
-    void assign(const unsigned char* ptrValue);
+    void assignBuffer(const unsigned char* ptrValue);
 
 private:
     /**

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -43,7 +43,7 @@ public:
 class AvExport VideoFrame : public Frame
 {
 public:
-    VideoFrame(const VideoFrameDesc& desc);
+    VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocation = true);
     ~VideoFrame();
 
     /**

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -43,16 +43,23 @@ public:
 class AvExport VideoFrame : public Frame
 {
 public:
-    VideoFrame(const VideoFrameDesc& ref);
-    VideoFrame(const Frame& otherFrame);
+    VideoFrame(const VideoFrameDesc& desc);
     ~VideoFrame();
+
+    /**
+     * @brief Allocate the image buffer of the frame.
+     * @warning The allocated data should be freed by the caller.
+     * @see freeData
+     */
+    void allocateData();
+    void freeData();
 
     size_t getWidth() const { return _frame->width; }
     size_t getHeight() const { return _frame->height; }
     AVPixelFormat getPixelFormat() const { return static_cast<AVPixelFormat>(_frame->format); }
     VideoFrameDesc desc() const { return VideoFrameDesc(getWidth(), getHeight(), getPixelFormat()); }
 
-    size_t getSize() const; ///< in bytes/**
+    size_t getSize() const;
 
     /**
      * @brief Assign the given value to all the data of the picture.
@@ -65,25 +72,6 @@ public:
      * @see getSize
      */
     void assign(const unsigned char* ptrValue);
-
-private:
-    /**
-     * @brief Allocate the image buffer of the frame.
-     * @warning The allocated data should be freed by the caller.
-     * @see freeAVPicture
-     */
-    void allocateAVPicture(const VideoFrameDesc& desc);
-
-    /**
-     * @brief Free the image buffer of the frame.
-     */
-    void freeAVPicture();
-
-    /**
-     * @note To allocate new image buffer if needed.
-     * @see allocateAVPicture
-     */
-    friend class VideoGenerator;
 };
 }
 

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -42,6 +42,11 @@ public:
  */
 class AvExport VideoFrame : public IFrame
 {
+private:
+    VideoFrame(const VideoFrame& otherFrame);
+    VideoFrame& operator=(const VideoFrame& otherFrame);
+
+
 public:
     VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocation = true);
     ~VideoFrame();

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -21,8 +21,8 @@ namespace avtranscoder
 struct AvExport VideoFrameDesc
 {
 public:
-    VideoFrameDesc(const size_t width = 0, const size_t height = 0, const AVPixelFormat pixelFormat = AV_PIX_FMT_NONE);
     VideoFrameDesc(const size_t width, const size_t height, const std::string& pixelFormatName);
+    VideoFrameDesc(const ProfileLoader::Profile& profile);
 
     /**
      * @brief Set the attributes from the given profile.
@@ -45,7 +45,6 @@ class AvExport VideoFrame : public IFrame
 private:
     VideoFrame(const VideoFrame& otherFrame);
     VideoFrame& operator=(const VideoFrame& otherFrame);
-
 
 public:
     VideoFrame(const VideoFrameDesc& desc, const bool forceDataAllocation = true);

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -57,7 +57,7 @@ public:
      */
     void allocateData();
     void freeData();
-    size_t getSize() const;
+    size_t getDataSize() const;
 
     size_t getWidth() const { return _frame->width; }
     size_t getHeight() const { return _frame->height; }

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -57,7 +57,6 @@ public:
     size_t getWidth() const { return _frame->width; }
     size_t getHeight() const { return _frame->height; }
     AVPixelFormat getPixelFormat() const { return static_cast<AVPixelFormat>(_frame->format); }
-    VideoFrameDesc desc() const { return VideoFrameDesc(getWidth(), getHeight(), getPixelFormat()); }
 
     size_t getSize() const;
 

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -45,6 +45,7 @@ class AvExport VideoFrame : public Frame
 public:
     VideoFrame(const VideoFrameDesc& ref);
     VideoFrame(const Frame& otherFrame);
+    ~VideoFrame();
 
     size_t getWidth() const { return _frame->width; }
     size_t getHeight() const { return _frame->height; }
@@ -68,8 +69,15 @@ public:
 private:
     /**
      * @brief Allocate the image buffer of the frame.
+     * @warning The allocated data should be freed by the caller.
+     * @see freeAVPicture
      */
     void allocateAVPicture(const VideoFrameDesc& desc);
+
+    /**
+     * @brief Free the image buffer of the frame.
+     */
+    void freeAVPicture();
 
     /**
      * @note To allocate new image buffer if needed.

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -72,6 +72,14 @@ public:
      * @see getSize
      */
     void assign(const unsigned char* ptrValue);
+
+private:
+    /**
+     * @brief Description of the frame to allocate.
+     * @warning This description could be different from the current frame (a decoder could have reseted it).
+     * We need to keep this description to allocate again the frame even if it was reseted.
+     */
+    const VideoFrameDesc _desc;
 };
 }
 

--- a/src/AvTranscoder/data/decoded/VideoFrame.hpp
+++ b/src/AvTranscoder/data/decoded/VideoFrame.hpp
@@ -57,12 +57,11 @@ public:
      */
     void allocateData();
     void freeData();
+    size_t getSize() const;
 
     size_t getWidth() const { return _frame->width; }
     size_t getHeight() const { return _frame->height; }
     AVPixelFormat getPixelFormat() const { return static_cast<AVPixelFormat>(_frame->format); }
-
-    size_t getSize() const;
 
     void assignBuffer(const unsigned char* ptrValue);
 

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -128,6 +128,22 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
     const size_t srcNbChannels = avCodecContext.channels;
     const size_t bytePerSample = av_get_bytes_per_sample((AVSampleFormat)frameBuffer.getAVFrame().format);
 
+    // check if each expected channel exists
+    for(std::vector<size_t>::const_iterator channelIndex = channelIndexArray.begin();
+        channelIndex != channelIndexArray.end(); ++channelIndex)
+    {
+        if((*channelIndex) > srcNbChannels - 1)
+        {
+            std::stringstream msg;
+            msg << "The channel at index ";
+            msg << (*channelIndex);
+            msg << " doesn't exist (srcNbChannels = ";
+            msg << srcNbChannels;
+            msg << ").";
+            throw std::runtime_error(msg.str());
+        }
+    }
+
     // if all channels of the stream are extracted
     if(srcNbChannels == channelIndexArray.size())
         return decodeNextFrame(frameBuffer);
@@ -144,22 +160,6 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
                                                           avCodecContext.sample_fmt, noAlignment);
     if(decodedSize == 0)
         return false;
-
-    // check if each expected channel exists
-    for(std::vector<size_t>::const_iterator channelIndex = channelIndexArray.begin();
-        channelIndex != channelIndexArray.end(); ++channelIndex)
-    {
-        if((*channelIndex) > srcNbChannels - 1)
-        {
-            std::stringstream msg;
-            msg << "The channel at index ";
-            msg << (*channelIndex);
-            msg << " doesn't exist (srcNbChannels = ";
-            msg << srcNbChannels;
-            msg << ").";
-            throw std::runtime_error(msg.str());
-        }
-    }
 
     // copy frame properties of decoded frame
     audioBuffer.copyProperties(allDataOfNextFrame);

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -159,8 +159,6 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
             throw std::runtime_error(msg.str());
         }
     }
-    // allocate data to store the subpart of the next frame
-    audioBuffer.allocateData();
 
     // copy frame properties of decoded frame
     audioBuffer.copyProperties(allDataOfNextFrame);

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -126,7 +126,6 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
 {
     AVCodecContext& avCodecContext = _inputStream->getAudioCodec().getAVCodecContext();
     const size_t srcNbChannels = avCodecContext.channels;
-    const size_t bytePerSample = av_get_bytes_per_sample((AVSampleFormat)frameBuffer.getAVFrame().format);
 
     // check if each expected channel exists
     for(std::vector<size_t>::const_iterator channelIndex = channelIndexArray.begin();
@@ -155,6 +154,7 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
         return false;
 
     const int dstNbChannels = 1;
+    const size_t bytePerSample = audioBuffer.getBytesPerSample();
     const int noAlignment = 0;
     const size_t decodedSize = av_samples_get_buffer_size(NULL, dstNbChannels, frameBuffer.getAVFrame().nb_samples,
                                                           avCodecContext.sample_fmt, noAlignment);

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -162,8 +162,6 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
 
     // copy frame properties of decoded frame
     audioBuffer.copyProperties(allDataOfNextFrame);
-    av_frame_set_channels(&audioBuffer.getAVFrame(), channelIndexArray.size());
-    av_frame_set_channel_layout(&audioBuffer.getAVFrame(), av_get_default_channel_layout(channelIndexArray.size()));
     audioBuffer.setNbSamplesPerChannel(allDataOfNextFrame.getNbSamplesPerChannel());
 
     // @todo manage cases with data of frame not only on data[0] (use _frame.linesize)

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -133,7 +133,7 @@ bool AudioDecoder::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t>
 
     // else decode all data in an intermediate buffer
     AudioFrame& audioBuffer = static_cast<AudioFrame&>(frameBuffer);
-    AudioFrame allDataOfNextFrame(AudioFrameDesc(audioBuffer.getSampleRate(), srcNbChannels, audioBuffer.getSampleFormat()));
+    AudioFrame allDataOfNextFrame(AudioFrameDesc(audioBuffer.getSampleRate(), srcNbChannels, audioBuffer.getSampleFormat()), false);
     if(!decodeNextFrame(allDataOfNextFrame))
         return false;
 

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -161,9 +161,11 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
     if(decodedSize == 0)
         return false;
 
-    // copy frame properties of decoded frame
+    // update the output frame
     audioBuffer.copyProperties(allDataOfNextFrame);
     audioBuffer.setNbSamplesPerChannel(allDataOfNextFrame.getNbSamplesPerChannel());
+    if(! audioBuffer.isDataAllocated())
+        audioBuffer.allocateData();
 
     // @todo manage cases with data of frame not only on data[0] (use _frame.linesize)
     unsigned char* src = allDataOfNextFrame.getData()[0];

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -153,8 +153,8 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
     if(!decodeNextFrame(allDataOfNextFrame))
         return false;
 
-    const int dstNbChannels = 1;
     const size_t bytePerSample = audioBuffer.getBytesPerSample();
+    const int dstNbChannels = channelIndexArray.size();
     const int noAlignment = 0;
     const size_t decodedSize = av_samples_get_buffer_size(NULL, dstNbChannels, frameBuffer.getAVFrame().nb_samples,
                                                           avCodecContext.sample_fmt, noAlignment);

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -76,7 +76,7 @@ void AudioDecoder::setupDecoder(const ProfileLoader::Profile& profile)
     _isSetup = true;
 }
 
-bool AudioDecoder::decodeNextFrame(Frame& frameBuffer)
+bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer)
 {
     bool decodeNextFrame = false;
     const size_t channelLayout = frameBuffer.getAVFrame().channel_layout;
@@ -121,7 +121,7 @@ bool AudioDecoder::decodeNextFrame(Frame& frameBuffer)
     return decodeNextFrame;
 }
 
-bool AudioDecoder::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray)
+bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray)
 {
     AVCodecContext& avCodecContext = _inputStream->getAudioCodec().getAVCodecContext();
     const size_t srcNbChannels = avCodecContext.channels;

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -132,7 +132,8 @@ bool AudioDecoder::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t>
         return decodeNextFrame(frameBuffer);
 
     // else decode all data in an intermediate buffer
-    AudioFrame allDataOfNextFrame(frameBuffer);
+    AudioFrame& audioBuffer = static_cast<AudioFrame&>(frameBuffer);
+    AudioFrame allDataOfNextFrame(AudioFrameDesc(audioBuffer.getSampleRate(), srcNbChannels, audioBuffer.getSampleFormat()));
     if(!decodeNextFrame(allDataOfNextFrame))
         return false;
 
@@ -158,9 +159,10 @@ bool AudioDecoder::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t>
             throw std::runtime_error(msg.str());
         }
     }
+    // allocate data to store the subpart of the next frame
+    audioBuffer.allocateData();
 
     // copy frame properties of decoded frame
-    AudioFrame& audioBuffer = static_cast<AudioFrame&>(frameBuffer);
     audioBuffer.copyProperties(allDataOfNextFrame);
     av_frame_set_channels(&audioBuffer.getAVFrame(), channelIndexArray.size());
     av_frame_set_channel_layout(&audioBuffer.getAVFrame(), av_get_default_channel_layout(channelIndexArray.size()));

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -1,5 +1,6 @@
 #include "AudioDecoder.hpp"
 
+#include <AvTranscoder/util.hpp>
 #include <AvTranscoder/codec/ICodec.hpp>
 #include <AvTranscoder/stream/InputStream.hpp>
 #include <AvTranscoder/data/decoded/AudioFrame.hpp>
@@ -133,7 +134,7 @@ bool AudioDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t
 
     // else decode all data in an intermediate buffer
     AudioFrame& audioBuffer = static_cast<AudioFrame&>(frameBuffer);
-    AudioFrame allDataOfNextFrame(AudioFrameDesc(audioBuffer.getSampleRate(), srcNbChannels, audioBuffer.getSampleFormat()), false);
+    AudioFrame allDataOfNextFrame(AudioFrameDesc(audioBuffer.getSampleRate(), srcNbChannels, getSampleFormatName(audioBuffer.getSampleFormat())), false);
     if(!decodeNextFrame(allDataOfNextFrame))
         return false;
 

--- a/src/AvTranscoder/decoder/AudioDecoder.hpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.hpp
@@ -16,8 +16,8 @@ public:
 
     void setupDecoder(const ProfileLoader::Profile& profile = ProfileLoader::Profile());
 
-    bool decodeNextFrame(Frame& frameBuffer);
-    bool decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray);
+    bool decodeNextFrame(IFrame& frameBuffer);
+    bool decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray);
 
     void flushDecoder();
 

--- a/src/AvTranscoder/decoder/AudioGenerator.cpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.cpp
@@ -21,14 +21,6 @@ AudioGenerator::~AudioGenerator()
 
 bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
 {
-    // check the given frame
-    if(! frameBuffer.isAudioFrame())
-    {
-        LOG_WARN("The given frame to put data is not a valid audio frame: try to reallocate it.")
-        static_cast<AudioFrame&>(frameBuffer).freeAVSample();
-        static_cast<AudioFrame&>(frameBuffer).allocateAVSample(_frameDesc);
-    }
-
     // Generate silent
     if(!_inputFrame)
     {

--- a/src/AvTranscoder/decoder/AudioGenerator.cpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.cpp
@@ -25,7 +25,7 @@ bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
     if(! frameBuffer.isAudioFrame())
     {
         LOG_WARN("The given frame to put data is not a valid audio frame: try to reallocate it.")
-        frameBuffer.clear();
+        frameBuffer.unrefFrame();
         static_cast<AudioFrame&>(frameBuffer).allocateAVSample(_frameDesc);
     }
 

--- a/src/AvTranscoder/decoder/AudioGenerator.cpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.cpp
@@ -36,6 +36,7 @@ bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
         if(!_silent)
         {
             _silent = new AudioFrame(_frameDesc);
+            _silent->allocateData();
 
             std::stringstream msg;
             msg << "Generate a silence with the following features:" << std::endl;

--- a/src/AvTranscoder/decoder/AudioGenerator.cpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.cpp
@@ -19,7 +19,7 @@ AudioGenerator::~AudioGenerator()
     delete _silent;
 }
 
-bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
+bool AudioGenerator::decodeNextFrame(IFrame& frameBuffer)
 {
     // Generate silent
     if(!_inputFrame)
@@ -53,7 +53,7 @@ bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
     return true;
 }
 
-bool AudioGenerator::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray)
+bool AudioGenerator::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray)
 {
     return decodeNextFrame(frameBuffer);
 }

--- a/src/AvTranscoder/decoder/AudioGenerator.cpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.cpp
@@ -28,7 +28,6 @@ bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
         if(!_silent)
         {
             _silent = new AudioFrame(_frameDesc);
-            _silent->allocateData();
 
             std::stringstream msg;
             msg << "Generate a silence with the following features:" << std::endl;

--- a/src/AvTranscoder/decoder/AudioGenerator.cpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.cpp
@@ -25,7 +25,7 @@ bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
     if(! frameBuffer.isAudioFrame())
     {
         LOG_WARN("The given frame to put data is not a valid audio frame: try to reallocate it.")
-        frameBuffer.unrefFrame();
+        static_cast<AudioFrame&>(frameBuffer).freeAVSample();
         static_cast<AudioFrame&>(frameBuffer).allocateAVSample(_frameDesc);
     }
 
@@ -50,7 +50,7 @@ bool AudioGenerator::decodeNextFrame(Frame& frameBuffer)
             _silent->setNbSamplesPerChannel(frameBuffer.getAVFrame().nb_samples);
         }
         LOG_DEBUG("Copy data of the silence when decode next frame")
-        frameBuffer.refFrame(*_silent);
+        frameBuffer.copyData(*_silent);
     }
     // Take audio frame from _inputFrame
     else

--- a/src/AvTranscoder/decoder/AudioGenerator.hpp
+++ b/src/AvTranscoder/decoder/AudioGenerator.hpp
@@ -19,18 +19,18 @@ public:
 
     ~AudioGenerator();
 
-    bool decodeNextFrame(Frame& frameBuffer);
-    bool decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray);
+    bool decodeNextFrame(IFrame& frameBuffer);
+    bool decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray);
 
     /**
      * @brief Force to return this frame when calling the decoding methods.
      * @param inputFrame: could have other properties than the given frame when decoding (will be converted).
      * @see decodeNextFrame
      */
-    void setNextFrame(Frame& inputFrame) { _inputFrame = &inputFrame; }
+    void setNextFrame(IFrame& inputFrame) { _inputFrame = &inputFrame; }
 
 private:
-    Frame* _inputFrame;              ///< Has link (no ownership)
+    IFrame* _inputFrame;              ///< Has link (no ownership)
     AudioFrame* _silent;             ///< The generated silent (has ownership)
     const AudioFrameDesc _frameDesc; ///< The description of the given frame buffer when decoding.
     AudioTransform _audioTransform;  ///< To transform the specified data when decoding.

--- a/src/AvTranscoder/decoder/IDecoder.hpp
+++ b/src/AvTranscoder/decoder/IDecoder.hpp
@@ -2,7 +2,7 @@
 #define _AV_TRANSCODER_ESSENCE_STREAM_IDECODER_HPP_
 
 #include <AvTranscoder/common.hpp>
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/IFrame.hpp>
 #include <AvTranscoder/profile/ProfileLoader.hpp>
 
 namespace avtranscoder
@@ -28,7 +28,7 @@ public:
      * decoder. The caller may not write to it.
      * @return status of decoding
      */
-    virtual bool decodeNextFrame(Frame& frameBuffer) = 0;
+    virtual bool decodeNextFrame(IFrame& frameBuffer) = 0;
 
     /**
      * @brief Decode substream of next frame
@@ -36,14 +36,14 @@ public:
      * @param channelIndexArray: list of channels to extract
      * @return status of decoding
      */
-    virtual bool decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray) = 0;
+    virtual bool decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray) = 0;
 
     /**
      * @brief Set the next frame of the input stream (which bypass the work of decoding)
      * @note Not yet implemented for VideoDecoder and AudioDecoder
      * @param inputFrame: the new next frame
      */
-    virtual void setNextFrame(Frame& inputFrame) {}
+    virtual void setNextFrame(IFrame& inputFrame) {}
 
     /**
      * @brief Reset the internal decoder state / flush internal buffers.

--- a/src/AvTranscoder/decoder/VideoDecoder.cpp
+++ b/src/AvTranscoder/decoder/VideoDecoder.cpp
@@ -74,7 +74,7 @@ void VideoDecoder::setupDecoder(const ProfileLoader::Profile& profile)
     _isSetup = true;
 }
 
-bool VideoDecoder::decodeNextFrame(Frame& frameBuffer)
+bool VideoDecoder::decodeNextFrame(IFrame& frameBuffer)
 {
     bool decodeNextFrame = false;
 
@@ -115,7 +115,7 @@ bool VideoDecoder::decodeNextFrame(Frame& frameBuffer)
     return decodeNextFrame;
 }
 
-bool VideoDecoder::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray)
+bool VideoDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray)
 {
     return false;
 }

--- a/src/AvTranscoder/decoder/VideoDecoder.hpp
+++ b/src/AvTranscoder/decoder/VideoDecoder.hpp
@@ -16,8 +16,8 @@ public:
 
     void setupDecoder(const ProfileLoader::Profile& profile = ProfileLoader::Profile());
 
-    bool decodeNextFrame(Frame& frameBuffer);
-    bool decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray);
+    bool decodeNextFrame(IFrame& frameBuffer);
+    bool decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray);
 
     void flushDecoder();
 

--- a/src/AvTranscoder/decoder/VideoGenerator.cpp
+++ b/src/AvTranscoder/decoder/VideoGenerator.cpp
@@ -19,7 +19,7 @@ VideoGenerator::~VideoGenerator()
     delete _blackImage;
 }
 
-bool VideoGenerator::decodeNextFrame(Frame& frameBuffer)
+bool VideoGenerator::decodeNextFrame(IFrame& frameBuffer)
 {
     // Generate black image
     if(!_inputFrame)
@@ -54,7 +54,7 @@ bool VideoGenerator::decodeNextFrame(Frame& frameBuffer)
     return true;
 }
 
-bool VideoGenerator::decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray)
+bool VideoGenerator::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray)
 {
     return false;
 }

--- a/src/AvTranscoder/decoder/VideoGenerator.cpp
+++ b/src/AvTranscoder/decoder/VideoGenerator.cpp
@@ -25,7 +25,7 @@ bool VideoGenerator::decodeNextFrame(Frame& frameBuffer)
     if(! frameBuffer.isVideoFrame())
     {
         LOG_WARN("The given frame to put data is not a valid video frame: try to reallocate it.")
-        frameBuffer.unrefFrame();
+        static_cast<VideoFrame&>(frameBuffer).freeAVPicture();
         static_cast<VideoFrame&>(frameBuffer).allocateAVPicture(_frameDesc);
     }
 

--- a/src/AvTranscoder/decoder/VideoGenerator.cpp
+++ b/src/AvTranscoder/decoder/VideoGenerator.cpp
@@ -31,7 +31,7 @@ bool VideoGenerator::decodeNextFrame(IFrame& frameBuffer)
             VideoFrameDesc blackDesc(_frameDesc._width, _frameDesc._height, "rgb24");
             _blackImage = new VideoFrame(blackDesc);
             const unsigned char fillChar = 0;
-            _blackImage->assign(fillChar);
+            _blackImage->assignValue(fillChar);
 
             std::stringstream msg;
             msg << "Generate a black image with the following features:" << std::endl;

--- a/src/AvTranscoder/decoder/VideoGenerator.cpp
+++ b/src/AvTranscoder/decoder/VideoGenerator.cpp
@@ -21,14 +21,6 @@ VideoGenerator::~VideoGenerator()
 
 bool VideoGenerator::decodeNextFrame(Frame& frameBuffer)
 {
-    // check the given frame
-    if(! frameBuffer.isVideoFrame())
-    {
-        LOG_WARN("The given frame to put data is not a valid video frame: try to reallocate it.")
-        static_cast<VideoFrame&>(frameBuffer).freeAVPicture();
-        static_cast<VideoFrame&>(frameBuffer).allocateAVPicture(_frameDesc);
-    }
-
     // Generate black image
     if(!_inputFrame)
     {

--- a/src/AvTranscoder/decoder/VideoGenerator.cpp
+++ b/src/AvTranscoder/decoder/VideoGenerator.cpp
@@ -25,7 +25,7 @@ bool VideoGenerator::decodeNextFrame(Frame& frameBuffer)
     if(! frameBuffer.isVideoFrame())
     {
         LOG_WARN("The given frame to put data is not a valid video frame: try to reallocate it.")
-        frameBuffer.clear();
+        frameBuffer.unrefFrame();
         static_cast<VideoFrame&>(frameBuffer).allocateAVPicture(_frameDesc);
     }
 

--- a/src/AvTranscoder/decoder/VideoGenerator.hpp
+++ b/src/AvTranscoder/decoder/VideoGenerator.hpp
@@ -18,18 +18,18 @@ public:
     VideoGenerator(const VideoFrameDesc& frameDesc);
     ~VideoGenerator();
 
-    bool decodeNextFrame(Frame& frameBuffer);
-    bool decodeNextFrame(Frame& frameBuffer, const std::vector<size_t> channelIndexArray);
+    bool decodeNextFrame(IFrame& frameBuffer);
+    bool decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray);
 
     /**
      * @brief Force to return this frame when calling the decoding methods.
      * @param inputFrame: could have other properties than the given frame when decoding (will be converted).
      * @see decodeNextFrame
      */
-    void setNextFrame(Frame& inputFrame) { _inputFrame = &inputFrame; }
+    void setNextFrame(IFrame& inputFrame) { _inputFrame = &inputFrame; }
 
 private:
-    Frame* _inputFrame;              ///< A frame given from outside (has link, no ownership)
+    IFrame* _inputFrame;              ///< A frame given from outside (has link, no ownership)
     VideoFrame* _blackImage;         ///< The generated RGB black image (has ownership)
     const VideoFrameDesc _frameDesc; ///< The description of the given frame buffer when decoding.
     VideoTransform _videoTransform;  ///< To transform data of the back image to the given Frame when decoding.

--- a/src/AvTranscoder/encoder/AudioEncoder.cpp
+++ b/src/AvTranscoder/encoder/AudioEncoder.cpp
@@ -91,7 +91,7 @@ void AudioEncoder::setupEncoder(const ProfileLoader::Profile& profile)
     }
 }
 
-bool AudioEncoder::encodeFrame(const Frame& sourceFrame, CodedData& codedFrame)
+bool AudioEncoder::encodeFrame(const IFrame& sourceFrame, CodedData& codedFrame)
 {
     AVCodecContext& avCodecContext = _codec.getAVCodecContext();
 

--- a/src/AvTranscoder/encoder/AudioEncoder.hpp
+++ b/src/AvTranscoder/encoder/AudioEncoder.hpp
@@ -18,7 +18,7 @@ public:
                            const ProfileLoader::Profile& profile = ProfileLoader::Profile());
     void setupEncoder(const ProfileLoader::Profile& profile = ProfileLoader::Profile());
 
-    bool encodeFrame(const Frame& sourceFrame, CodedData& codedFrame);
+    bool encodeFrame(const IFrame& sourceFrame, CodedData& codedFrame);
     bool encodeFrame(CodedData& codedFrame);
 
     ICodec& getCodec() { return _codec; }

--- a/src/AvTranscoder/encoder/IEncoder.hpp
+++ b/src/AvTranscoder/encoder/IEncoder.hpp
@@ -1,7 +1,7 @@
 #ifndef _AV_TRANSCODER_ESSENCE_STREAM_IENCODER_HPP_
 #define _AV_TRANSCODER_ESSENCE_STREAM_IENCODER_HPP_
 
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/IFrame.hpp>
 #include <AvTranscoder/data/coded/CodedData.hpp>
 #include <AvTranscoder/codec/ICodec.hpp>
 #include <AvTranscoder/profile/ProfileLoader.hpp>
@@ -28,7 +28,7 @@ public:
      * @return status of encoding
      * @throw runtime_error if the encoded process failed.
      */
-    virtual bool encodeFrame(const Frame& sourceFrame, CodedData& codedFrame) = 0;
+    virtual bool encodeFrame(const IFrame& sourceFrame, CodedData& codedFrame) = 0;
 
     /**
      * @brief Get the frames remaining into the encoder

--- a/src/AvTranscoder/encoder/VideoEncoder.cpp
+++ b/src/AvTranscoder/encoder/VideoEncoder.cpp
@@ -104,7 +104,7 @@ void VideoEncoder::setupEncoder(const ProfileLoader::Profile& profile)
     }
 }
 
-bool VideoEncoder::encodeFrame(const Frame& sourceFrame, CodedData& codedFrame)
+bool VideoEncoder::encodeFrame(const IFrame& sourceFrame, CodedData& codedFrame)
 {
     AVCodecContext& avCodecContext = _codec.getAVCodecContext();
 

--- a/src/AvTranscoder/encoder/VideoEncoder.hpp
+++ b/src/AvTranscoder/encoder/VideoEncoder.hpp
@@ -18,7 +18,7 @@ public:
                            const ProfileLoader::Profile& profile = ProfileLoader::Profile());
     void setupEncoder(const ProfileLoader::Profile& profile = ProfileLoader::Profile());
 
-    bool encodeFrame(const Frame& sourceFrame, CodedData& codedFrame);
+    bool encodeFrame(const IFrame& sourceFrame, CodedData& codedFrame);
     bool encodeFrame(CodedData& codedFrame);
 
     ICodec& getCodec() { return _codec; }

--- a/src/AvTranscoder/file/FormatContext.cpp
+++ b/src/AvTranscoder/file/FormatContext.cpp
@@ -8,6 +8,7 @@ namespace avtranscoder
 
 FormatContext::FormatContext(const std::string& filename, int req_flags, AVDictionary** options)
     : _avFormatContext(NULL)
+    , _avStreamAllocated()
     , _flags(req_flags)
     , _options()
     , _isOpen(false)
@@ -31,6 +32,7 @@ FormatContext::FormatContext(const std::string& filename, int req_flags, AVDicti
 
 FormatContext::FormatContext(int req_flags)
     : _avFormatContext(NULL)
+    , _avStreamAllocated()
     , _flags(req_flags)
     , _options()
     , _isOpen(false)
@@ -45,8 +47,8 @@ FormatContext::~FormatContext()
         return;
 
     // free the streams added
-    for(unsigned int i = 0; i < _avFormatContext->nb_streams; ++i)
-        avcodec_close(_avFormatContext->streams[i]->codec);
+    for(std::vector<AVStream*>::iterator it = _avStreamAllocated.begin(); it != _avStreamAllocated.end(); ++it)
+        avcodec_close((*it)->codec);
 
     // free the format context
     if(_isOpen)
@@ -143,6 +145,7 @@ AVStream& FormatContext::addAVStream(const AVCodec& avCodec)
     {
         throw std::runtime_error("Unable to add new video stream");
     }
+    _avStreamAllocated.push_back(stream);
     return *stream;
 }
 

--- a/src/AvTranscoder/file/FormatContext.cpp
+++ b/src/AvTranscoder/file/FormatContext.cpp
@@ -12,7 +12,7 @@ FormatContext::FormatContext(const std::string& filename, int req_flags, AVDicti
     , _options()
     , _isOpen(false)
 {
-    int ret = avformat_open_input(&_avFormatContext, filename.c_str(), NULL, options);
+    const int ret = avformat_open_input(&_avFormatContext, filename.c_str(), NULL, options);
     if(ret < 0)
     {
         std::string msg = "Unable to open file ";
@@ -44,10 +44,14 @@ FormatContext::~FormatContext()
     if(!_avFormatContext)
         return;
 
+    // free the streams added
+    for(unsigned int i = 0; i < _avFormatContext->nb_streams; ++i)
+        avcodec_close(_avFormatContext->streams[i]->codec);
+
+    // free the format context
     if(_isOpen)
         avformat_close_input(&_avFormatContext);
-    else
-        avformat_free_context(_avFormatContext);
+    avformat_free_context(_avFormatContext);
     _avFormatContext = NULL;
 }
 

--- a/src/AvTranscoder/file/FormatContext.hpp
+++ b/src/AvTranscoder/file/FormatContext.hpp
@@ -23,11 +23,13 @@ private:
 public:
     /**
      * @brief Allocate an AVFormatContext by opening an input file
+     * @see InputFile
      */
     FormatContext(const std::string& filename, int req_flags = 0, AVDictionary** options = NULL);
 
     /**
      * @brief Allocate an AVFormatContext with default values
+     * @see OutputFile
      */
     FormatContext(int req_flags = 0);
 

--- a/src/AvTranscoder/file/FormatContext.hpp
+++ b/src/AvTranscoder/file/FormatContext.hpp
@@ -122,6 +122,7 @@ public:
 
 private:
     AVFormatContext* _avFormatContext; ///< Has ownership
+    std::vector<AVStream*> _avStreamAllocated; ///< Has link (no ownership)
     const int _flags;                  ///< Flags with which the options are loaded (see AV_OPT_FLAG_xxx)
     OptionMap _options;
     bool _isOpen; ///< Is the AVFormatContext open (in constructor with a filename)

--- a/src/AvTranscoder/filter/Filter.hpp
+++ b/src/AvTranscoder/filter/Filter.hpp
@@ -30,8 +30,8 @@ public:
 #endif
 
 private:
-    AVFilter* _filter;
-    AVFilterContext* _context;
+    AVFilter* _filter;  ///< Has ownership
+    AVFilterContext* _context;  ///< Has link (no ownership)
     std::string _options;
     std::string _instanceName;
 };

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -30,7 +30,7 @@ FilterGraph::~FilterGraph()
 {
     for(std::vector<Filter*>::iterator it = _filters.begin(); it < _filters.end(); ++it)
     {
-        it = _filters.erase(it);
+        delete(*it);
     }
     avfilter_graph_free(&_graph);
 }
@@ -168,9 +168,8 @@ void FilterGraph::addInBuffer(const std::vector<IFrame*>& inputs)
             throw std::runtime_error("Cannot create input buffer of filter graph: the given frame is invalid.");
 
         // add in buffer
-        Filter* in = new Filter(filterName, filterOptions.str(), "in");
         LOG_INFO("Add filter '" << filterName << "' at the beginning of the graph.")
-        _filters.insert(_filters.begin(), in);
+        _filters.insert(_filters.begin(), new Filter(filterName, filterOptions.str(), "in"));
     }
 }
 

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -40,8 +40,7 @@ void FilterGraph::process(const std::vector<Frame*>& inputs, Frame& output)
     if(!hasFilters())
     {
         LOG_DEBUG("No filter to process: reference first input frame to the given output.")
-        output.unrefFrame();
-        output.refFrame(*inputs.at(0));
+        output.copyData(*inputs.at(0));
         return;
     }
 

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -35,7 +35,7 @@ FilterGraph::~FilterGraph()
     avfilter_graph_free(&_graph);
 }
 
-void FilterGraph::process(const std::vector<Frame*>& inputs, Frame& output)
+void FilterGraph::process(const std::vector<IFrame*>& inputs, IFrame& output)
 {
     // init filter graph
     if(!_isInit)
@@ -74,7 +74,7 @@ Filter& FilterGraph::addFilter(const std::string& filterName, const std::string&
     return *_filters.back();
 }
 
-void FilterGraph::init(const std::vector<Frame*>& inputs, Frame& output)
+void FilterGraph::init(const std::vector<IFrame*>& inputs, IFrame& output)
 {
     // push filters to the graph
     addInBuffer(inputs);
@@ -134,9 +134,9 @@ void FilterGraph::pushFilter(Filter& filter)
     }
 }
 
-void FilterGraph::addInBuffer(const std::vector<Frame*>& inputs)
+void FilterGraph::addInBuffer(const std::vector<IFrame*>& inputs)
 {
-    for(std::vector<Frame*>::const_reverse_iterator it = inputs.rbegin(); it != inputs.rend(); ++it)
+    for(std::vector<IFrame*>::const_reverse_iterator it = inputs.rbegin(); it != inputs.rend(); ++it)
     {
         std::string filterName;
         std::stringstream filterOptions;
@@ -174,7 +174,7 @@ void FilterGraph::addInBuffer(const std::vector<Frame*>& inputs)
     }
 }
 
-void FilterGraph::addOutBuffer(const Frame& output)
+void FilterGraph::addOutBuffer(const IFrame& output)
 {
     std::string filterName;
 

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -40,7 +40,7 @@ void FilterGraph::process(const std::vector<Frame*>& inputs, Frame& output)
     if(!hasFilters())
     {
         LOG_DEBUG("No filter to process: reference first input frame to the given output.")
-        output.clear();
+        output.unrefFrame();
         output.refFrame(*inputs.at(0));
         return;
     }

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -37,13 +37,6 @@ FilterGraph::~FilterGraph()
 
 void FilterGraph::process(const std::vector<Frame*>& inputs, Frame& output)
 {
-    if(!hasFilters())
-    {
-        LOG_DEBUG("No filter to process: reference first input frame to the given output.")
-        output.copyData(*inputs.at(0));
-        return;
-    }
-
     // init filter graph
     if(!_isInit)
         init(inputs, output);

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -4,7 +4,7 @@
 #include <AvTranscoder/common.hpp>
 #include <AvTranscoder/filter/Filter.hpp>
 #include <AvTranscoder/codec/ICodec.hpp>
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/IFrame.hpp>
 
 #include <vector>
 
@@ -55,7 +55,7 @@ public:
      * @warning the output frame must be cleared once it has been used
      * @see the av_buffersink_get_frame function documentation
      */
-    void process(const std::vector<Frame*>& inputs, Frame& output);
+    void process(const std::vector<IFrame*>& inputs, IFrame& output);
 
     /**
      * @return If at least one filter has been added to the filter graph
@@ -69,7 +69,7 @@ private:
      * @see pushInBuffer
      * @see pushOutBuffer
      */
-    void init(const std::vector<Frame*>& inputs, Frame& output);
+    void init(const std::vector<IFrame*>& inputs, IFrame& output);
 
     /**
      * @brief Push the given Filter to the graph.
@@ -78,8 +78,8 @@ private:
 
     ///@{
     /// @brief Add the input and output buffers at the beginning and the end of the list of filters.
-    void addInBuffer(const std::vector<Frame*>& inputs);
-    void addOutBuffer(const Frame& output);
+    void addInBuffer(const std::vector<IFrame*>& inputs);
+    void addOutBuffer(const IFrame& output);
     //@}
 
 private:

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -57,12 +57,12 @@ public:
      */
     void process(const std::vector<Frame*>& inputs, Frame& output);
 
-private:
     /**
      * @return If at least one filter has been added to the filter graph
      */
     bool hasFilters() const { return !_filters.empty(); }
 
+private:
     /**
      * @brief Initialize the graph of filters to process.
      * @see pushFilterToGraph

--- a/src/AvTranscoder/properties/VideoProperties.cpp
+++ b/src/AvTranscoder/properties/VideoProperties.cpp
@@ -3,6 +3,7 @@
 #include <AvTranscoder/properties/util.hpp>
 #include <AvTranscoder/properties/FileProperties.hpp>
 #include <AvTranscoder/progress/NoDisplayProgress.hpp>
+#include <AvTranscoder/data/decoded/VideoFrame.hpp>
 
 extern "C" {
 #include <libavutil/avutil.h>
@@ -341,10 +342,13 @@ size_t VideoProperties::getBitRate() const
     // discard no frame type when decode
     _codecContext->skip_frame = AVDISCARD_NONE;
 
-    AVFrame avFrame;
     AVPacket pkt;
     av_init_packet(&pkt);
+
     avcodec_open2(_codecContext, _codec, NULL);
+
+    VideoFrame frame(VideoFrameDesc(getWidth(), getHeight(), getPixelProperties().getAVPixelFormat()), false);
+    AVFrame& avFrame = frame.getAVFrame();
 
     int gotFrame = 0;
     size_t nbDecodedFrames = 0;
@@ -565,7 +569,9 @@ void VideoProperties::analyseGopStructure(IProgress& progress)
             // Initialize the AVCodecContext to use the given AVCodec
             avcodec_open2(_codecContext, _codec, NULL);
 
-            AVFrame avFrame;
+            VideoFrame frame(VideoFrameDesc(getWidth(), getHeight(), getPixelProperties().getAVPixelFormat()), false);
+            AVFrame& avFrame = frame.getAVFrame();
+
             size_t count = 0;
             int gotFrame = 0;
             int positionOfFirstKeyFrame = -1;

--- a/src/AvTranscoder/properties/VideoProperties.cpp
+++ b/src/AvTranscoder/properties/VideoProperties.cpp
@@ -347,7 +347,7 @@ size_t VideoProperties::getBitRate() const
 
     avcodec_open2(_codecContext, _codec, NULL);
 
-    VideoFrame frame(VideoFrameDesc(getWidth(), getHeight(), getPixelProperties().getAVPixelFormat()), false);
+    VideoFrame frame(VideoFrameDesc(getWidth(), getHeight(), getPixelProperties().getPixelFormatName()), false);
     AVFrame& avFrame = frame.getAVFrame();
 
     int gotFrame = 0;
@@ -569,7 +569,7 @@ void VideoProperties::analyseGopStructure(IProgress& progress)
             // Initialize the AVCodecContext to use the given AVCodec
             avcodec_open2(_codecContext, _codec, NULL);
 
-            VideoFrame frame(VideoFrameDesc(getWidth(), getHeight(), getPixelProperties().getAVPixelFormat()), false);
+            VideoFrame frame(VideoFrameDesc(getWidth(), getHeight(), getPixelProperties().getPixelFormatName()), false);
             AVFrame& avFrame = frame.getAVFrame();
 
             size_t count = 0;

--- a/src/AvTranscoder/reader/AudioReader.cpp
+++ b/src/AvTranscoder/reader/AudioReader.cpp
@@ -46,10 +46,7 @@ void AudioReader::init()
 
     // create src frame
     const AudioFrameDesc srcFrameDesc = _inputFile->getStream(_streamIndex).getAudioCodec().getAudioFrameDesc();
-    bool allocateDecodedData = false;
-    if(_channelIndex != -1)
-        allocateDecodedData = true;
-    _srcFrame = new AudioFrame(srcFrameDesc, allocateDecodedData);
+    _srcFrame = new AudioFrame(srcFrameDesc, false);
     AudioFrame* srcFrame = static_cast<AudioFrame*>(_srcFrame);
     // create dst frame
     _outputSampleRate = srcFrame->getSampleRate();

--- a/src/AvTranscoder/reader/AudioReader.cpp
+++ b/src/AvTranscoder/reader/AudioReader.cpp
@@ -46,7 +46,10 @@ void AudioReader::init()
 
     // create src frame
     const AudioFrameDesc srcFrameDesc = _inputFile->getStream(_streamIndex).getAudioCodec().getAudioFrameDesc();
-    _srcFrame = new AudioFrame(srcFrameDesc);
+    bool allocateDecodedData = false;
+    if(_channelIndex != -1)
+        allocateDecodedData = true;
+    _srcFrame = new AudioFrame(srcFrameDesc, allocateDecodedData);
     AudioFrame* srcFrame = static_cast<AudioFrame*>(_srcFrame);
     // create dst frame
     _outputSampleRate = srcFrame->getSampleRate();

--- a/src/AvTranscoder/reader/AudioReader.cpp
+++ b/src/AvTranscoder/reader/AudioReader.cpp
@@ -54,7 +54,7 @@ void AudioReader::init()
     // create dst frame
     _outputSampleRate = srcFrame->getSampleRate();
     _outputNbChannels = (_channelIndex == -1) ? srcFrame->getNbChannels() : 1;
-    _dstFrame = new AudioFrame(AudioFrameDesc(_outputSampleRate, _outputNbChannels, _outputSampleFormat));
+    _dstFrame = new AudioFrame(AudioFrameDesc(_outputSampleRate, _outputNbChannels, getSampleFormatName(_outputSampleFormat)));
 
     // generator
     _generator = new AudioGenerator(srcFrameDesc);
@@ -79,6 +79,6 @@ void AudioReader::updateOutput(const size_t sampleRate, const size_t nbChannels,
     _outputSampleFormat = getAVSampleFormat(sampleFormat);
     // update dst frame
     delete _dstFrame;
-    _dstFrame = new AudioFrame(AudioFrameDesc(_outputSampleRate, _outputNbChannels, _outputSampleFormat));
+    _dstFrame = new AudioFrame(AudioFrameDesc(_outputSampleRate, _outputNbChannels, getSampleFormatName(_outputSampleFormat)));
 }
 }

--- a/src/AvTranscoder/reader/AudioReader.cpp
+++ b/src/AvTranscoder/reader/AudioReader.cpp
@@ -45,7 +45,8 @@ void AudioReader::init()
     _currentDecoder = _decoder;
 
     // create src frame
-    _srcFrame = new AudioFrame(_inputFile->getStream(_streamIndex).getAudioCodec().getAudioFrameDesc());
+    const AudioFrameDesc srcFrameDesc = _inputFile->getStream(_streamIndex).getAudioCodec().getAudioFrameDesc();
+    _srcFrame = new AudioFrame(srcFrameDesc);
     AudioFrame* srcFrame = static_cast<AudioFrame*>(_srcFrame);
     // create dst frame
     _outputSampleRate = srcFrame->getSampleRate();
@@ -53,7 +54,7 @@ void AudioReader::init()
     _dstFrame = new AudioFrame(AudioFrameDesc(_outputSampleRate, _outputNbChannels, _outputSampleFormat));
 
     // generator
-    _generator = new AudioGenerator(srcFrame->desc());
+    _generator = new AudioGenerator(srcFrameDesc);
 
     // create transform
     _transform = new AudioTransform();

--- a/src/AvTranscoder/reader/IReader.cpp
+++ b/src/AvTranscoder/reader/IReader.cpp
@@ -86,6 +86,9 @@ IFrame* IReader::readFrameAt(const size_t frame)
         // generate data (ie silence or black)
         if(_continueWithGenerator)
         {
+            // allocate the frame since the process will continue with some generated data
+            if(! _srcFrame->isDataAllocated())
+                _srcFrame->allocateData();
             _currentDecoder = _generator;
             return readFrameAt(frame);
         }

--- a/src/AvTranscoder/reader/IReader.cpp
+++ b/src/AvTranscoder/reader/IReader.cpp
@@ -46,17 +46,17 @@ IReader::~IReader()
         delete _inputFile;
 }
 
-Frame* IReader::readNextFrame()
+IFrame* IReader::readNextFrame()
 {
     return readFrameAt(_currentFrame + 1);
 }
 
-Frame* IReader::readPrevFrame()
+IFrame* IReader::readPrevFrame()
 {
     return readFrameAt(_currentFrame - 1);
 }
 
-Frame* IReader::readFrameAt(const size_t frame)
+IFrame* IReader::readFrameAt(const size_t frame)
 {
     assert(_currentDecoder != NULL);
     assert(_transform != NULL);

--- a/src/AvTranscoder/reader/IReader.hpp
+++ b/src/AvTranscoder/reader/IReader.hpp
@@ -6,7 +6,7 @@
 #include <AvTranscoder/file/InputFile.hpp>
 #include <AvTranscoder/properties/StreamProperties.hpp>
 #include <AvTranscoder/decoder/IDecoder.hpp>
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/IFrame.hpp>
 #include <AvTranscoder/transform/ITransform.hpp>
 
 namespace avtranscoder
@@ -37,20 +37,20 @@ public:
      * @return Get next frame after decoding
      * @see readFrameAt
      */
-    Frame* readNextFrame();
+    IFrame* readNextFrame();
 
     /**
      * @return Get previous frame after decoding
      * @see readFrameAt
      */
-    Frame* readPrevFrame();
+    IFrame* readPrevFrame();
 
     /**
      * @return Get indicated frame after decoding
      * @warn Returns NULL if there is no more frame to read.
      * @see continueWithGenerator
      */
-    Frame* readFrameAt(const size_t frame);
+    IFrame* readFrameAt(const size_t frame);
 
     /**
      * @brief Get the properties of the source stream read.
@@ -70,8 +70,8 @@ protected:
     IDecoder* _generator;
     IDecoder* _currentDecoder; ///< Link to _inputDecoder or _generator
 
-    Frame* _srcFrame;
-    Frame* _dstFrame;
+    IFrame* _srcFrame;
+    IFrame* _dstFrame;
 
     ITransform* _transform;
 

--- a/src/AvTranscoder/reader/VideoReader.cpp
+++ b/src/AvTranscoder/reader/VideoReader.cpp
@@ -44,7 +44,8 @@ void VideoReader::init()
     _currentDecoder = _decoder;
 
     // create src frame
-    _srcFrame = new VideoFrame(_inputFile->getStream(_streamIndex).getVideoCodec().getVideoFrameDesc());
+    const VideoFrameDesc srcFrameDesc = _inputFile->getStream(_streamIndex).getVideoCodec().getVideoFrameDesc();
+    _srcFrame = new VideoFrame(srcFrameDesc);
     VideoFrame* srcFrame = static_cast<VideoFrame*>(_srcFrame);
     // create dst frame
     _outputWidth = srcFrame->getWidth();
@@ -52,7 +53,7 @@ void VideoReader::init()
     _dstFrame = new VideoFrame(VideoFrameDesc(_outputWidth, _outputHeight, getOutputPixelFormat()));
 
     // generator
-    _generator = new VideoGenerator(srcFrame->desc());
+    _generator = new VideoGenerator(srcFrameDesc);
 
     // create transform
     _transform = new VideoTransform();

--- a/src/AvTranscoder/reader/VideoReader.cpp
+++ b/src/AvTranscoder/reader/VideoReader.cpp
@@ -45,7 +45,7 @@ void VideoReader::init()
 
     // create src frame
     const VideoFrameDesc srcFrameDesc = _inputFile->getStream(_streamIndex).getVideoCodec().getVideoFrameDesc();
-    _srcFrame = new VideoFrame(srcFrameDesc);
+    _srcFrame = new VideoFrame(srcFrameDesc, false);
     VideoFrame* srcFrame = static_cast<VideoFrame*>(_srcFrame);
     // create dst frame
     _outputWidth = srcFrame->getWidth();

--- a/src/AvTranscoder/reader/VideoReader.cpp
+++ b/src/AvTranscoder/reader/VideoReader.cpp
@@ -1,5 +1,6 @@
 #include "VideoReader.hpp"
 
+#include <AvTranscoder/util.hpp>
 #include <AvTranscoder/decoder/VideoDecoder.hpp>
 #include <AvTranscoder/decoder/VideoGenerator.hpp>
 #include <AvTranscoder/data/decoded/VideoFrame.hpp>
@@ -50,7 +51,7 @@ void VideoReader::init()
     // create dst frame
     _outputWidth = srcFrame->getWidth();
     _outputHeight = srcFrame->getHeight();
-    _dstFrame = new VideoFrame(VideoFrameDesc(_outputWidth, _outputHeight, getOutputPixelFormat()));
+    _dstFrame = new VideoFrame(VideoFrameDesc(_outputWidth, _outputHeight, getPixelFormatName(getOutputPixelFormat())));
 
     // generator
     _generator = new VideoGenerator(srcFrameDesc);
@@ -75,6 +76,6 @@ void VideoReader::updateOutput(const size_t width, const size_t height, const st
     _outputPixelProperties = PixelProperties(pixelFormat);
     // update dst frame
     delete _dstFrame;
-    _dstFrame = new VideoFrame(VideoFrameDesc(_outputWidth, _outputHeight, getOutputPixelFormat()));
+    _dstFrame = new VideoFrame(VideoFrameDesc(_outputWidth, _outputHeight, getPixelFormatName(getOutputPixelFormat())));
 }
 }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -599,7 +599,10 @@ bool StreamTranscoder::processTranscode()
                 switchToGeneratorDecoder();
                 LOG_INFO("Force reallocation of the decoded data buffers since the decoders could have cleared them.")
                 for(std::vector<IFrame*>::iterator it = _decodedData.begin(); it != _decodedData.end(); ++it)
-                    (*it)->allocateData();
+                {
+                    if(! (*it)->isDataAllocated())
+                        (*it)->allocateData();
+                }
                 return processTranscode();
             }
             return false;

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -247,7 +247,7 @@ void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInput
             _decodedData.push_back(inputFrame);
 
             // generator decoder
-            _generators.push_back(new VideoGenerator(inputFrame->desc()));
+            _generators.push_back(new VideoGenerator(inputStream.getVideoCodec().getVideoFrameDesc()));
 
             break;
         }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -547,6 +547,26 @@ bool StreamTranscoder::processTranscode()
             decodingStatus = decodingStatus && _currentDecoder->decodeNextFrame(*_decodedData.at(index));
     }
 
+    // check the next data buffers in case of audio frames
+    if(_decodedData.at(0)->isAudioFrame())
+    {
+        const int nbInputSamplesPerChannel = _decodedData.at(0)->getAVFrame().nb_samples;
+        if(nbInputSamplesPerChannel > _filteredData->getAVFrame().nb_samples)
+        {
+            LOG_WARN("The buffer of filtered data is too small: reallocate it.")
+            _filteredData->freeData();
+            _filteredData->getAVFrame().nb_samples = nbInputSamplesPerChannel;
+            _filteredData->allocateData();
+        }
+        if(nbInputSamplesPerChannel > _transformedData->getAVFrame().nb_samples)
+        {
+            LOG_WARN("The buffer of transformed data is too small: reallocate it.")
+            _transformedData->freeData();
+            _transformedData->getAVFrame().nb_samples = nbInputSamplesPerChannel;
+            _transformedData->allocateData();
+        }
+    }
+
     // Transform
     CodedData data;
     if(decodingStatus)

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -57,11 +57,9 @@ StreamTranscoder::StreamTranscoder(IInputStream& inputStream, IOutputFile& outpu
                 _generators.push_back(new VideoGenerator(inputFrameDesc));
 
                 // buffers to process
-                _decodedData.push_back(new VideoFrame(inputFrameDesc));
+                _decodedData.push_back(new VideoFrame(inputFrameDesc, false));
                 _filteredData = new VideoFrame(inputFrameDesc);
-                _filteredData->allocateData();
                 _transformedData = new VideoFrame(inputFrameDesc);
-                _transformedData->allocateData();
 
                 // transform
                 _transform = new VideoTransform();
@@ -95,11 +93,9 @@ StreamTranscoder::StreamTranscoder(IInputStream& inputStream, IOutputFile& outpu
                 _generators.push_back(new AudioGenerator(inputFrameDesc));
 
                 // buffers to process
-                _decodedData.push_back(new AudioFrame(inputFrameDesc));
+                _decodedData.push_back(new AudioFrame(inputFrameDesc, false));
                 _filteredData = new AudioFrame(inputFrameDesc);
-                _filteredData->allocateData();
                 _transformedData = new AudioFrame(inputFrameDesc);
-                _transformedData->allocateData();
 
                 // transform
                 _transform = new AudioTransform();
@@ -179,9 +175,7 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
 
             // buffers to process
             _filteredData = new VideoFrame(outputVideo->getVideoCodec().getVideoFrameDesc());
-            _filteredData->allocateData();
             _transformedData = new VideoFrame(outputVideo->getVideoCodec().getVideoFrameDesc());
-            _transformedData->allocateData();
 
             // transform
             _transform = new VideoTransform();
@@ -219,9 +213,7 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
                 inputFrameDesc._nbChannels = nbOutputChannels;
 
             _filteredData = new AudioFrame(inputFrameDesc);
-            _filteredData->allocateData();
             _transformedData = new AudioFrame(outputAudio->getAudioCodec().getAudioFrameDesc());
-            _transformedData->allocateData();
 
             // transform
             _transform = new AudioTransform();
@@ -251,7 +243,7 @@ void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInput
             _currentDecoder = inputVideo;
 
             // buffers to get the decoded data
-            VideoFrame* inputFrame = new VideoFrame(inputStream.getVideoCodec().getVideoFrameDesc());
+            VideoFrame* inputFrame = new VideoFrame(inputStream.getVideoCodec().getVideoFrameDesc(), false);
             _decodedData.push_back(inputFrame);
 
             // generator decoder
@@ -271,7 +263,7 @@ void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInput
             AudioFrameDesc inputFrameDesc(inputStream.getAudioCodec().getAudioFrameDesc());
             if(inputStreamDesc.demultiplexing())
                 inputFrameDesc._nbChannels = inputStreamDesc._channelIndexArray.size();
-            _decodedData.push_back(new AudioFrame(inputFrameDesc));
+            _decodedData.push_back(new AudioFrame(inputFrameDesc, false));
 
             // generator decoder
             _generators.push_back(new AudioGenerator(inputFrameDesc));
@@ -320,13 +312,9 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
         // buffers to process
         VideoFrameDesc outputFrameDesc = inputFrameDesc;
         outputFrameDesc.setParameters(profile);
-        VideoFrame* decodedData = new VideoFrame(inputFrameDesc);
-        decodedData->allocateData();
-        _decodedData.push_back(decodedData);
+        _decodedData.push_back(new VideoFrame(inputFrameDesc));
         _filteredData = new VideoFrame(inputFrameDesc);
-        _filteredData->allocateData();
         _transformedData = new VideoFrame(outputFrameDesc);
-        _transformedData->allocateData();
 
         // transform
         _transform = new VideoTransform();
@@ -357,13 +345,9 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
         // buffers to process
         AudioFrameDesc outputFrameDesc = inputFrameDesc;
         outputFrameDesc.setParameters(profile);
-        AudioFrame* decodedData = new AudioFrame(inputFrameDesc);
-        decodedData->allocateData();
-        _decodedData.push_back(decodedData);
+        _decodedData.push_back(new AudioFrame(inputFrameDesc));
         _filteredData = new AudioFrame(inputFrameDesc);
-        _filteredData->allocateData();
         _transformedData = new AudioFrame(outputFrameDesc);
-        _transformedData->allocateData();
 
         // transform
         _transform = new AudioTransform();

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -174,7 +174,7 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
             _outputStream = &outputFile.addVideoStream(outputVideo->getVideoCodec());
 
             // buffers to process
-            _filteredData = new VideoFrame(outputVideo->getVideoCodec().getVideoFrameDesc());
+            _filteredData = new VideoFrame(inputStream.getVideoCodec().getVideoFrameDesc());
             _transformedData = new VideoFrame(outputVideo->getVideoCodec().getVideoFrameDesc());
 
             // transform

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -261,9 +261,13 @@ void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInput
 
             // buffers to get the decoded data
             AudioFrameDesc inputFrameDesc(inputStream.getAudioCodec().getAudioFrameDesc());
+            bool allocateDecodedData = false;
             if(inputStreamDesc.demultiplexing())
+            {
                 inputFrameDesc._nbChannels = inputStreamDesc._channelIndexArray.size();
-            _decodedData.push_back(new AudioFrame(inputFrameDesc, false));
+                allocateDecodedData = true;
+            }
+            _decodedData.push_back(new AudioFrame(inputFrameDesc, allocateDecodedData));
 
             // generator decoder
             _generators.push_back(new AudioGenerator(inputFrameDesc));

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -333,8 +333,7 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
     else if(profile.find(constants::avProfileType)->second == constants::avProfileTypeAudio)
     {
         AudioCodec inputAudioCodec(eCodecTypeEncoder, profile.find(constants::avProfileCodec)->second);
-        AudioFrameDesc inputFrameDesc;
-        inputFrameDesc.setParameters(profile);
+        AudioFrameDesc inputFrameDesc(profile);
         inputAudioCodec.setAudioParameters(inputFrameDesc);
 
         // generator decoder

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -301,8 +301,7 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
     if(profile.find(constants::avProfileType)->second == constants::avProfileTypeVideo)
     {
         VideoCodec inputVideoCodec(eCodecTypeEncoder, profile.find(constants::avProfileCodec)->second);
-        VideoFrameDesc inputFrameDesc;
-        inputFrameDesc.setParameters(profile);
+        VideoFrameDesc inputFrameDesc(profile);
         inputVideoCodec.setImageParameters(inputFrameDesc);
 
         // generator decoder

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -550,7 +550,7 @@ bool StreamTranscoder::processTranscode()
         LOG_DEBUG("Convert")
         _transform->convert(*_filteredData, *_transformedData);
 
-        _filteredData->clear();
+        _filteredData->unrefFrame();
 
         LOG_DEBUG("Encode")
         _outputEncoder->encodeFrame(*_transformedData, data);

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -57,7 +57,7 @@ StreamTranscoder::StreamTranscoder(IInputStream& inputStream, IOutputFile& outpu
                 _generators.push_back(new VideoGenerator(inputFrameDesc));
 
                 // buffers to process
-                _decodedData.push_back(new VideoFrame(inputFrameDesc, false));
+                _decodedData.push_back(new VideoFrame(inputFrameDesc));
                 _filteredData = new VideoFrame(inputFrameDesc);
                 _transformedData = new VideoFrame(inputFrameDesc);
 
@@ -93,7 +93,7 @@ StreamTranscoder::StreamTranscoder(IInputStream& inputStream, IOutputFile& outpu
                 _generators.push_back(new AudioGenerator(inputFrameDesc));
 
                 // buffers to process
-                _decodedData.push_back(new AudioFrame(inputFrameDesc, false));
+                _decodedData.push_back(new AudioFrame(inputFrameDesc));
                 _filteredData = new AudioFrame(inputFrameDesc);
                 _transformedData = new AudioFrame(inputFrameDesc);
 

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -261,13 +261,9 @@ void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInput
 
             // buffers to get the decoded data
             AudioFrameDesc inputFrameDesc(inputStream.getAudioCodec().getAudioFrameDesc());
-            bool allocateDecodedData = false;
             if(inputStreamDesc.demultiplexing())
-            {
                 inputFrameDesc._nbChannels = inputStreamDesc._channelIndexArray.size();
-                allocateDecodedData = true;
-            }
-            _decodedData.push_back(new AudioFrame(inputFrameDesc, allocateDecodedData));
+            _decodedData.push_back(new AudioFrame(inputFrameDesc, false));
 
             // generator decoder
             _generators.push_back(new AudioGenerator(inputFrameDesc));

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -368,7 +368,7 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
 
 StreamTranscoder::~StreamTranscoder()
 {
-    for(std::vector<Frame*>::iterator it = _decodedData.begin(); it != _decodedData.end(); ++it)
+    for(std::vector<IFrame*>::iterator it = _decodedData.begin(); it != _decodedData.end(); ++it)
     {
         delete(*it);
     }
@@ -546,7 +546,7 @@ bool StreamTranscoder::processTranscode()
     CodedData data;
     if(decodingStatus)
     {
-        Frame* dataToTransform = NULL;
+        IFrame* dataToTransform = NULL;
         if(_filterGraph->hasFilters())
         {
             LOG_DEBUG("Filtering")
@@ -573,7 +573,7 @@ bool StreamTranscoder::processTranscode()
             {
                 switchToGeneratorDecoder();
                 // force reallocation of the buffers since de decoders have cleared them
-                for(std::vector<Frame*>::iterator it = _decodedData.begin(); it != _decodedData.end(); ++it)
+                for(std::vector<IFrame*>::iterator it = _decodedData.begin(); it != _decodedData.end(); ++it)
                     (*it)->allocateData();
                 return processTranscode();
             }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -320,7 +320,9 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
         // buffers to process
         VideoFrameDesc outputFrameDesc = inputFrameDesc;
         outputFrameDesc.setParameters(profile);
-        _decodedData.push_back(new VideoFrame(inputFrameDesc));
+        VideoFrame* decodedData = new VideoFrame(inputFrameDesc);
+        decodedData->allocateData();
+        _decodedData.push_back(decodedData);
         _filteredData = new VideoFrame(inputFrameDesc);
         _filteredData->allocateData();
         _transformedData = new VideoFrame(outputFrameDesc);
@@ -355,7 +357,9 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
         // buffers to process
         AudioFrameDesc outputFrameDesc = inputFrameDesc;
         outputFrameDesc.setParameters(profile);
-        _decodedData.push_back(new AudioFrame(inputFrameDesc));
+        AudioFrame* decodedData = new AudioFrame(inputFrameDesc);
+        decodedData->allocateData();
+        _decodedData.push_back(decodedData);
         _filteredData = new AudioFrame(inputFrameDesc);
         _filteredData->allocateData();
         _transformedData = new AudioFrame(outputFrameDesc);

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -550,8 +550,6 @@ bool StreamTranscoder::processTranscode()
         LOG_DEBUG("Convert")
         _transform->convert(*_filteredData, *_transformedData);
 
-        _filteredData->unrefFrame();
-
         LOG_DEBUG("Encode")
         _outputEncoder->encodeFrame(*_transformedData, data);
     }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -59,7 +59,9 @@ StreamTranscoder::StreamTranscoder(IInputStream& inputStream, IOutputFile& outpu
                 // buffers to process
                 _decodedData.push_back(new VideoFrame(inputFrameDesc));
                 _filteredData = new VideoFrame(inputFrameDesc);
+                _filteredData->allocateData();
                 _transformedData = new VideoFrame(inputFrameDesc);
+                _transformedData->allocateData();
 
                 // transform
                 _transform = new VideoTransform();
@@ -95,7 +97,9 @@ StreamTranscoder::StreamTranscoder(IInputStream& inputStream, IOutputFile& outpu
                 // buffers to process
                 _decodedData.push_back(new AudioFrame(inputFrameDesc));
                 _filteredData = new AudioFrame(inputFrameDesc);
+                _filteredData->allocateData();
                 _transformedData = new AudioFrame(inputFrameDesc);
+                _transformedData->allocateData();
 
                 // transform
                 _transform = new AudioTransform();
@@ -175,7 +179,9 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
 
             // buffers to process
             _filteredData = new VideoFrame(outputVideo->getVideoCodec().getVideoFrameDesc());
+            _filteredData->allocateData();
             _transformedData = new VideoFrame(outputVideo->getVideoCodec().getVideoFrameDesc());
+            _transformedData->allocateData();
 
             // transform
             _transform = new VideoTransform();
@@ -213,7 +219,9 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
                 inputFrameDesc._nbChannels = nbOutputChannels;
 
             _filteredData = new AudioFrame(inputFrameDesc);
+            _filteredData->allocateData();
             _transformedData = new AudioFrame(outputAudio->getAudioCodec().getAudioFrameDesc());
+            _transformedData->allocateData();
 
             // transform
             _transform = new AudioTransform();
@@ -314,7 +322,9 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
         outputFrameDesc.setParameters(profile);
         _decodedData.push_back(new VideoFrame(inputFrameDesc));
         _filteredData = new VideoFrame(inputFrameDesc);
+        _filteredData->allocateData();
         _transformedData = new VideoFrame(outputFrameDesc);
+        _transformedData->allocateData();
 
         // transform
         _transform = new VideoTransform();
@@ -347,7 +357,9 @@ StreamTranscoder::StreamTranscoder(IOutputFile& outputFile, const ProfileLoader:
         outputFrameDesc.setParameters(profile);
         _decodedData.push_back(new AudioFrame(inputFrameDesc));
         _filteredData = new AudioFrame(inputFrameDesc);
+        _filteredData->allocateData();
         _transformedData = new AudioFrame(outputFrameDesc);
+        _transformedData->allocateData();
 
         // transform
         _transform = new AudioTransform();

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -588,6 +588,9 @@ bool StreamTranscoder::processTranscode()
             if(_needToSwitchToGenerator)
             {
                 switchToGeneratorDecoder();
+                // force reallocation of the buffers since de decoders have cleared them
+                for(std::vector<Frame*>::iterator it = _decodedData.begin(); it != _decodedData.end(); ++it)
+                    (*it)->allocateData();
                 return processTranscode();
             }
             return false;

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -553,14 +553,14 @@ bool StreamTranscoder::processTranscode()
         const int nbInputSamplesPerChannel = _decodedData.at(0)->getAVFrame().nb_samples;
         if(nbInputSamplesPerChannel > _filteredData->getAVFrame().nb_samples)
         {
-            LOG_WARN("The buffer of filtered data is too small: reallocate it.")
+            LOG_WARN("The buffer of filtered data corresponds to a frame of " << _filteredData->getAVFrame().nb_samples << " samples. The decoded buffer contains " << nbInputSamplesPerChannel << " samples. Reallocate it.")
             _filteredData->freeData();
             _filteredData->getAVFrame().nb_samples = nbInputSamplesPerChannel;
             _filteredData->allocateData();
         }
         if(nbInputSamplesPerChannel > _transformedData->getAVFrame().nb_samples)
         {
-            LOG_WARN("The buffer of transformed data is too small: reallocate it.")
+            LOG_WARN("The buffer of transformed data corresponds to a frame of " << _transformedData->getAVFrame().nb_samples << " samples. The decoded buffer contains " << nbInputSamplesPerChannel << " samples. Reallocate it.")
             _transformedData->freeData();
             _transformedData->getAVFrame().nb_samples = nbInputSamplesPerChannel;
             _transformedData->allocateData();

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -134,9 +134,9 @@ private:
     std::vector<IInputStream*> _inputStreams;   ///< List of input stream to read next packet (has link, no ownership)
     IOutputStream* _outputStream; ///< Output stream to wrap next packet (has link, no ownership)
 
-    std::vector<Frame*> _decodedData; ///< List of buffers of decoded data (has ownership).
-    Frame* _filteredData;  ///< Buffer of filtered data (has ownership).
-    Frame* _transformedData;  ///< Buffer of transformed data (has ownership).
+    std::vector<IFrame*> _decodedData; ///< List of buffers of decoded data (has ownership).
+    IFrame* _filteredData;  ///< Buffer of filtered data (has ownership).
+    IFrame* _transformedData;  ///< Buffer of transformed data (has ownership).
 
     std::vector<IDecoder*> _inputDecoders;   ///< Decoders of packets read from _inputStream (has ownership)
     std::vector<IDecoder*> _generators;      ///< Generators of audio or video packets (has ownership)

--- a/src/AvTranscoder/transform/AudioTransform.cpp
+++ b/src/AvTranscoder/transform/AudioTransform.cpp
@@ -97,7 +97,7 @@ void AudioTransform::convert(const IFrame& srcFrame, IFrame& dstFrame)
     assert(src.getNbChannels() > 0);
     assert(src.getNbSamplesPerChannel() > 0);
     assert(src.getSampleFormat() != AV_SAMPLE_FMT_NONE);
-    assert(dst.getSize() > 0);
+    assert(dst.getDataSize() > 0);
 
     if(!_isInit)
         _isInit = init(src, dst);

--- a/src/AvTranscoder/transform/AudioTransform.cpp
+++ b/src/AvTranscoder/transform/AudioTransform.cpp
@@ -26,8 +26,9 @@ extern "C" {
 #endif
 }
 
-#include <stdexcept>
 #include <sstream>
+#include <cassert>
+#include <stdexcept>
 
 namespace avtranscoder
 {
@@ -43,7 +44,7 @@ AudioTransform::~AudioTransform()
     FreeResampleContext(&_audioConvertContext);
 }
 
-bool AudioTransform::init(const Frame& srcFrame, const Frame& dstFrame)
+bool AudioTransform::init(const AudioFrame& src, const AudioFrame& dst)
 {
     // Set convert context
     _audioConvertContext = AllocResampleContext();
@@ -51,9 +52,6 @@ bool AudioTransform::init(const Frame& srcFrame, const Frame& dstFrame)
     {
         throw std::runtime_error("unable to create audio convert context");
     }
-
-    const AudioFrame& src = static_cast<const AudioFrame&>(srcFrame);
-    const AudioFrame& dst = static_cast<const AudioFrame&>(dstFrame);
 
     av_opt_set_int(_audioConvertContext, "in_channel_layout", src.getChannelLayout(), 0);
     av_opt_set_int(_audioConvertContext, "out_channel_layout", dst.getChannelLayout(), 0);
@@ -92,8 +90,17 @@ bool AudioTransform::init(const Frame& srcFrame, const Frame& dstFrame)
 
 void AudioTransform::convert(const Frame& srcFrame, Frame& dstFrame)
 {
+    const AudioFrame& src = static_cast<const AudioFrame&>(srcFrame);
+    const AudioFrame& dst = static_cast<const AudioFrame&>(dstFrame);
+
+    assert(src.getSampleRate() > 0);
+    assert(src.getNbChannels() > 0);
+    assert(src.getNbSamplesPerChannel() > 0);
+    assert(src.getSampleFormat() != AV_SAMPLE_FMT_NONE);
+    assert(dst.getSize() > 0);
+
     if(!_isInit)
-        _isInit = init(srcFrame, dstFrame);
+        _isInit = init(src, dst);
 
     // if number of samples change from previous frame
     const size_t nbInputSamplesPerChannel = srcFrame.getAVFrame().nb_samples;
@@ -110,13 +117,9 @@ void AudioTransform::convert(const Frame& srcFrame, Frame& dstFrame)
         swr_convert(_audioConvertContext, dstData, nbInputSamplesPerChannel, srcData, nbInputSamplesPerChannel);
 #endif
 
+    // update the number of samples of the output frame
     if(nbOutputSamplesPerChannel < 0)
-    {
-        throw std::runtime_error("unable to convert audio samples");
-    }
-    else
-    {
-        dstFrame.getAVFrame().nb_samples = nbOutputSamplesPerChannel;
-    }
+        throw std::runtime_error("Unable to convert audio samples");
+    dstFrame.getAVFrame().nb_samples = nbOutputSamplesPerChannel;
 }
 }

--- a/src/AvTranscoder/transform/AudioTransform.cpp
+++ b/src/AvTranscoder/transform/AudioTransform.cpp
@@ -88,7 +88,7 @@ bool AudioTransform::init(const AudioFrame& src, const AudioFrame& dst)
     return true;
 }
 
-void AudioTransform::convert(const Frame& srcFrame, Frame& dstFrame)
+void AudioTransform::convert(const IFrame& srcFrame, IFrame& dstFrame)
 {
     const AudioFrame& src = static_cast<const AudioFrame&>(srcFrame);
     const AudioFrame& dst = static_cast<const AudioFrame&>(dstFrame);

--- a/src/AvTranscoder/transform/AudioTransform.hpp
+++ b/src/AvTranscoder/transform/AudioTransform.hpp
@@ -26,7 +26,7 @@ public:
     AudioTransform();
     ~AudioTransform();
 
-    void convert(const Frame& srcFrame, Frame& dstFrame);
+    void convert(const IFrame& srcFrame, IFrame& dstFrame);
 
 private:
     bool init(const AudioFrame& src, const AudioFrame& dst);

--- a/src/AvTranscoder/transform/AudioTransform.hpp
+++ b/src/AvTranscoder/transform/AudioTransform.hpp
@@ -3,8 +3,7 @@
 
 #include "ITransform.hpp"
 
-#include <AvTranscoder/common.hpp>
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/AudioFrame.hpp>
 
 #ifdef AVTRANSCODER_LIBAV_DEPENDENCY
 #define ResampleContext AVAudioResampleContext
@@ -30,7 +29,7 @@ public:
     void convert(const Frame& srcFrame, Frame& dstFrame);
 
 private:
-    bool init(const Frame& srcFrame, const Frame& dstFrame);
+    bool init(const AudioFrame& src, const AudioFrame& dst);
 
 private:
     ResampleContext* _audioConvertContext;

--- a/src/AvTranscoder/transform/ITransform.hpp
+++ b/src/AvTranscoder/transform/ITransform.hpp
@@ -15,9 +15,6 @@ public:
     virtual ~ITransform() {}
 
     virtual void convert(const Frame& src, Frame& dst) = 0;
-
-protected:
-    virtual bool init(const Frame& src, const Frame& dst) = 0;
 };
 }
 

--- a/src/AvTranscoder/transform/ITransform.hpp
+++ b/src/AvTranscoder/transform/ITransform.hpp
@@ -2,7 +2,7 @@
 #define _AV_TRANSCODER_ESSENCE_TRANSFORM_ESSENCE_TRANSFORM_HPP_
 
 #include <AvTranscoder/common.hpp>
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/IFrame.hpp>
 
 namespace avtranscoder
 {
@@ -14,7 +14,7 @@ public:
 
     virtual ~ITransform() {}
 
-    virtual void convert(const Frame& src, Frame& dst) = 0;
+    virtual void convert(const IFrame& src, IFrame& dst) = 0;
 };
 }
 

--- a/src/AvTranscoder/transform/VideoTransform.cpp
+++ b/src/AvTranscoder/transform/VideoTransform.cpp
@@ -68,7 +68,7 @@ void VideoTransform::convert(const IFrame& srcFrame, IFrame& dstFrame)
     assert(src.getWidth() > 0);
     assert(src.getHeight() > 0);
     assert(src.getPixelFormat() != AV_PIX_FMT_NONE);
-    assert(dst.getSize() > 0);
+    assert(dst.getDataSize() > 0);
 
     if(!_isInit)
         _isInit = init(src, dst);

--- a/src/AvTranscoder/transform/VideoTransform.cpp
+++ b/src/AvTranscoder/transform/VideoTransform.cpp
@@ -60,7 +60,7 @@ bool VideoTransform::init(const VideoFrame& src, const VideoFrame& dst)
     return true;
 }
 
-void VideoTransform::convert(const Frame& srcFrame, Frame& dstFrame)
+void VideoTransform::convert(const IFrame& srcFrame, IFrame& dstFrame)
 {
     const VideoFrame& src = static_cast<const VideoFrame&>(srcFrame);
     VideoFrame& dst = static_cast<VideoFrame&>(dstFrame);

--- a/src/AvTranscoder/transform/VideoTransform.cpp
+++ b/src/AvTranscoder/transform/VideoTransform.cpp
@@ -1,7 +1,5 @@
 #include "VideoTransform.hpp"
 
-#include <AvTranscoder/data/decoded/VideoFrame.hpp>
-
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
@@ -31,12 +29,8 @@ VideoTransform::~VideoTransform()
     sws_freeContext(_imageConvertContext);
 }
 
-bool VideoTransform::init(const Frame& srcFrame, const Frame& dstFrame)
+bool VideoTransform::init(const VideoFrame& src, const VideoFrame& dst)
 {
-    // Set convert context
-    const VideoFrame& src = static_cast<const VideoFrame&>(srcFrame);
-    const VideoFrame& dst = static_cast<const VideoFrame&>(dstFrame);
-
     const AVPixelFormat srcPixelFormat = src.getPixelFormat();
     const AVPixelFormat dstPixelFormat = dst.getPixelFormat();
 
@@ -71,12 +65,13 @@ void VideoTransform::convert(const Frame& srcFrame, Frame& dstFrame)
     const VideoFrame& src = static_cast<const VideoFrame&>(srcFrame);
     VideoFrame& dst = static_cast<VideoFrame&>(dstFrame);
 
-    assert(src.getWidth() != 0);
-    assert(src.getHeight() != 0);
+    assert(src.getWidth() > 0);
+    assert(src.getHeight() > 0);
     assert(src.getPixelFormat() != AV_PIX_FMT_NONE);
+    assert(dst.getSize() > 0);
 
     if(!_isInit)
-        _isInit = init(srcFrame, dstFrame);
+        _isInit = init(src, dst);
 
     if(!_imageConvertContext)
     {

--- a/src/AvTranscoder/transform/VideoTransform.hpp
+++ b/src/AvTranscoder/transform/VideoTransform.hpp
@@ -1,11 +1,9 @@
 #ifndef _AV_TRANSCODER_ESSENCE_TRANSFORM_VIDEO_ESSENCE_TRANSFORM_HPP
 #define _AV_TRANSCODER_ESSENCE_TRANSFORM_VIDEO_ESSENCE_TRANSFORM_HPP
 
-#include <vector>
-
 #include "ITransform.hpp"
 
-#include <AvTranscoder/data/decoded/Frame.hpp>
+#include <AvTranscoder/data/decoded/VideoFrame.hpp>
 
 class SwsContext;
 
@@ -25,7 +23,7 @@ public:
     void convert(const Frame& srcFrame, Frame& dstFrame);
 
 private:
-    bool init(const Frame& srcFrame, const Frame& dstFrame);
+    bool init(const VideoFrame& src, const VideoFrame& dst);
 
     SwsContext* _imageConvertContext;
     bool _isInit;

--- a/src/AvTranscoder/transform/VideoTransform.hpp
+++ b/src/AvTranscoder/transform/VideoTransform.hpp
@@ -20,7 +20,7 @@ public:
     VideoTransform();
     ~VideoTransform();
 
-    void convert(const Frame& srcFrame, Frame& dstFrame);
+    void convert(const IFrame& srcFrame, IFrame& dstFrame);
 
 private:
     bool init(const VideoFrame& src, const VideoFrame& dst);

--- a/test/pyTest/testAudioFrame.py
+++ b/test/pyTest/testAudioFrame.py
@@ -24,7 +24,7 @@ def testInvalidAudioFrameManualAllocated():
     frame = av.AudioFrame(desc, False)
 
     assert_equals(frame.isDataAllocated(), False)
-    assert_equals(frame.getSize(), 0)
+    assert_equals(frame.getDataSize(), 0)
     assert_equals(frame.getSampleRate(), sampleRate)
     assert_equals(frame.getNbChannels(), nbChannels)
     assert_equals(frame.getChannelLayoutDesc(), "mono")
@@ -46,7 +46,7 @@ def testAudioFrame():
 
     assert_equals(frame.isDataAllocated(), True)
     assert_equals(frame.isAudioFrame(), True)
-    assert_equals(frame.getSize(), frame.getNbSamplesPerChannel() * frame.getBytesPerSample() * nbChannels)
+    assert_equals(frame.getDataSize(), frame.getNbSamplesPerChannel() * frame.getBytesPerSample() * nbChannels)
 
     frame.freeData()
     assert_equals(frame.isDataAllocated(), False)

--- a/test/pyTest/testAudioFrame.py
+++ b/test/pyTest/testAudioFrame.py
@@ -1,0 +1,52 @@
+from nose.tools import *
+
+from pyAvTranscoder import avtranscoder as av
+
+
+@raises(MemoryError)
+def testInvalidAudioFrameAutoAllocated():
+    """
+    Try to create an invalid AudioFrame automatically allocated.
+    """
+    desc = av.AudioFrameDesc(4800, 1, "toto")
+    av.AudioFrame(desc)
+
+
+@raises(MemoryError)
+def testInvalidAudioFrameManualAllocated():
+    """
+    Try to create an invalid AudioFrame manually allocated.
+    """
+    sampleRate = 48000
+    nbChannels = 1
+    sampleFormat = "titi"
+    desc = av.AudioFrameDesc(sampleRate, nbChannels, sampleFormat)
+    frame = av.AudioFrame(desc, False)
+
+    assert_equals(frame.isDataAllocated(), False)
+    assert_equals(frame.getSize(), 0)
+    assert_equals(frame.getSampleRate(), sampleRate)
+    assert_equals(frame.getNbChannels(), nbChannels)
+    assert_equals(frame.getChannelLayoutDesc(), "mono")
+    assert_equals(frame.getNbSamplesPerChannel(), 1920)
+    assert_equals(frame.getBytesPerSample(), 0)
+    assert_equals(av.getSampleFormatName(frame.getSampleFormat()), "")
+
+    frame.allocateData()
+
+def testAudioFrame():
+    """
+    Check the size and the data buffer of a AudioFrame.
+    """
+    sampleRate = 48000
+    nbChannels = 1
+    sampleFormat = "s32"
+    desc = av.AudioFrameDesc(sampleRate, nbChannels, sampleFormat)
+    frame = av.AudioFrame(desc)
+
+    assert_equals(frame.isDataAllocated(), True)
+    assert_equals(frame.isAudioFrame(), True)
+    assert_equals(frame.getSize(), frame.getNbSamplesPerChannel() * frame.getBytesPerSample() * nbChannels)
+
+    frame.freeData()
+    assert_equals(frame.isDataAllocated(), False)

--- a/test/pyTest/testAudioReader.py
+++ b/test/pyTest/testAudioReader.py
@@ -23,7 +23,7 @@ def testAudioReaderCreateNewInputFile():
         frame = reader.readNextFrame()
         if not frame:
             break
-        assert_greater(frame.getSize(), 0)
+        assert_greater(frame.getDataSize(), 0)
 
     # check if there is no next frame
     frame = reader.readNextFrame()
@@ -45,13 +45,13 @@ def testAudioReaderChannelsExtraction():
     nbChannels = readerOfAllChannels.getOutputNbChannels()
     # read first frame
     frame = readerOfAllChannels.readNextFrame()
-    sizeOfFrameWithAllChannels = frame.getSize()
+    sizeOfFrameWithAllChannels = frame.getDataSize()
 
     # create reader to read one channel of the audio stream
     readerOfOneChannel = av.AudioReader(inputFile, streamIndex, channelIndex)
     # read first frame
     frame = readerOfOneChannel.readNextFrame()
-    sizeOfFrameWithOneChannels = frame.getSize()
+    sizeOfFrameWithOneChannels = frame.getDataSize()
 
     assert_equals( sizeOfFrameWithAllChannels / nbChannels, sizeOfFrameWithOneChannels )
 
@@ -70,7 +70,7 @@ def testAudioReaderWithGenerator():
         frame = reader.readNextFrame()
         if not frame:
             break
-        assert_greater(frame.getSize(), 0)
+        assert_greater(frame.getDataSize(), 0)
 
     # check if there is no next frame
     assert_equals( reader.readNextFrame(), None )
@@ -82,4 +82,4 @@ def testAudioReaderWithGenerator():
         # assuming we generate data of 1920 samples of 2 bytes
         nbSamplesPerChannel = 1920
         bytesPerSample = 2
-        assert_equals(frame.getSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )
+        assert_equals(frame.getDataSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )

--- a/test/pyTest/testAudioReader.py
+++ b/test/pyTest/testAudioReader.py
@@ -10,6 +10,26 @@ from nose.tools import *
 from pyAvTranscoder import avtranscoder as av
 
 
+def testAudioReaderCreateNewInputFile():
+    """
+    Read a audio stream with the AudioReader.
+    The InputFile is created inside the reader.
+    """
+    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    reader = av.AudioReader(inputFileName)
+
+    # read all frames and check their size
+    while True:
+        frame = reader.readNextFrame()
+        if not frame:
+            break
+        assert_greater(frame.getSize(), 0)
+
+    # check if there is no next frame
+    frame = reader.readNextFrame()
+    assert_equals( reader.readNextFrame(), None )
+
+
 def testAudioReaderChannelsExtraction():
     """
     Read the same audio stream with several AudioReaders.

--- a/test/pyTest/testAudioReader.py
+++ b/test/pyTest/testAudioReader.py
@@ -1,0 +1,65 @@
+import os
+
+# Check if environment is setup to run the tests
+if os.environ.get('AVTRANSCODER_TEST_AUDIO_WAVE_FILE') is None:
+    from nose.plugins.skip import SkipTest
+    raise SkipTest("Need to define environment variables AVTRANSCODER_TEST_AUDIO_WAVE_FILE")
+
+from nose.tools import *
+
+from pyAvTranscoder import avtranscoder as av
+
+
+def testAudioReaderChannelsExtraction():
+    """
+    Read the same audio stream with several AudioReaders.
+    Compare decoded frames from reader of all channels, and of one channel.
+    """
+    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    inputFile = av.InputFile(inputFileName)
+    streamIndex = inputFile.getProperties().getAudioProperties()[0].getStreamIndex()
+    channelIndex = 0
+
+    # create reader to read all channels of the audio stream
+    readerOfAllChannels = av.AudioReader(inputFile, streamIndex)
+    nbChannels = readerOfAllChannels.getOutputNbChannels()
+    # read first frame
+    frame = readerOfAllChannels.readNextFrame()
+    sizeOfFrameWithAllChannels = frame.getSize()
+
+    # create reader to read one channel of the audio stream
+    readerOfOneChannel = av.AudioReader(inputFile, streamIndex, channelIndex)
+    # read first frame
+    frame = readerOfOneChannel.readNextFrame()
+    sizeOfFrameWithOneChannels = frame.getSize()
+
+    assert_equals( sizeOfFrameWithAllChannels / nbChannels, sizeOfFrameWithOneChannels )
+
+
+def testAudioReaderWithGenerator():
+    """
+    Read an audio stream with the AudioReader.
+    When there is no more data to decode, switch to a generator and process some frames.
+    """
+    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    inputFile = av.InputFile(inputFileName)
+    reader = av.AudioReader(inputFile)
+
+    # read all frames and check their size
+    while True:
+        frame = reader.readNextFrame()
+        if not frame:
+            break
+        assert_greater(frame.getSize(), 0)
+
+    # check if there is no next frame
+    assert_equals( reader.readNextFrame(), None )
+
+    # generate 10 frames of silence
+    reader.continueWithGenerator()
+    for i in xrange(0, 9):
+        frame = reader.readNextFrame()
+        # assuming we generate data of 1920 samples of 2 bytes
+        nbSamplesPerChannel = 1920
+        bytesPerSample = 2
+        assert_equals(frame.getSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )

--- a/test/pyTest/testReader.py
+++ b/test/pyTest/testReader.py
@@ -23,7 +23,7 @@ def testVideoReaderCreateNewInputFile():
 
     # read all frames and check their size
     for i in xrange(0, reader.getSourceVideoProperties().getNbFrames()):
-        frame = av.VideoFrame(reader.readNextFrame())
+        frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
         assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
@@ -43,7 +43,7 @@ def testVideoReaderReferenceInputFile():
 
     # read all frames and check their size
     for i in xrange(0, reader.getSourceVideoProperties().getNbFrames()):
-        frame = av.VideoFrame(reader.readNextFrame())
+        frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
         assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
@@ -65,13 +65,13 @@ def testAudioReaderChannelsExtraction():
     readerOfAllChannels = av.AudioReader(inputFile, streamIndex)
     nbChannels = readerOfAllChannels.getOutputNbChannels()
     # read first frame
-    frame = av.AudioFrame(readerOfAllChannels.readNextFrame())
+    frame = readerOfAllChannels.readNextFrame()
     sizeOfFrameWithAllChannels = frame.getSize()
 
     # create reader to read one channel of the audio stream
     readerOfOneChannel = av.AudioReader(inputFile, streamIndex, channelIndex)
     # read first frame
-    frame = av.AudioFrame(readerOfOneChannel.readNextFrame())
+    frame = readerOfOneChannel.readNextFrame()
     sizeOfFrameWithOneChannels = frame.getSize()
 
     assert_equals( sizeOfFrameWithAllChannels / nbChannels, sizeOfFrameWithOneChannels )
@@ -87,7 +87,7 @@ def testVideoReaderWithGenerator():
 
     # read all frames and check their size
     for i in xrange(0, reader.getSourceVideoProperties().getNbFrames()):
-        frame = av.VideoFrame(reader.readNextFrame())
+        frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
         assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
@@ -97,7 +97,7 @@ def testVideoReaderWithGenerator():
     # generate 10 frames of black
     reader.continueWithGenerator()
     for i in xrange(0, 9):
-        frame = av.VideoFrame(reader.readNextFrame())
+        frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
         assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
@@ -116,10 +116,7 @@ def testAudioReaderWithGenerator():
         frame = reader.readNextFrame()
         if not frame:
             break
-        frame = av.AudioFrame(frame)
-        nbSamplesPerChannel = frame.getNbSamplesPerChannel()
-        bytesPerSample = 2
-        assert_equals( frame.getSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )
+        assert_greater(frame.getSize(), 0)
 
     # check if there is no next frame
     assert_equals( reader.readNextFrame(), None )
@@ -127,7 +124,8 @@ def testAudioReaderWithGenerator():
     # generate 10 frames of silence
     reader.continueWithGenerator()
     for i in xrange(0, 9):
-        frame = av.AudioFrame(reader.readNextFrame())
-        nbSamplesPerChannel = frame.getNbSamplesPerChannel()
+        frame = reader.readNextFrame()
+        # assuming we generate data of 1920 samples of 2 bytes
+        nbSamplesPerChannel = 1920
         bytesPerSample = 2
-        assert_equals( frame.getSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )
+        assert_equals(frame.getSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )

--- a/test/pyTest/testSetFrame.py
+++ b/test/pyTest/testSetFrame.py
@@ -39,7 +39,7 @@ def testSetVideoFrame():
 
         # set video frame
         frame = av.VideoFrame(av.VideoFrameDesc(1920, 1080, "rgb24"))
-        frame.assign(i)
+        frame.assignValue(i)
         videoDecoder.setNextFrame( frame )
 
     # end process
@@ -85,7 +85,7 @@ def testSetAudioFrame():
 
         # set video frame
         frame = av.AudioFrame(av.AudioFrameDesc(44100, 1, "s16"))
-        frame.assign(i)
+        frame.assignValue(i)
         audioDecoder.setNextFrame( frame )
 
     # end process

--- a/test/pyTest/testTranscoderAdd.py
+++ b/test/pyTest/testTranscoderAdd.py
@@ -70,6 +70,25 @@ def testEmptyListOfInputs():
 
 
 @raises(RuntimeError)
+def testAddOneChannelWhichDoesNotExist():
+    """
+    Extract one audio channel from an input stream.
+    """
+    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    outputFileName = "testAddOneChannelWhichDoesNotExist.wav"
+
+    ouputFile = av.OutputFile(outputFileName)
+    transcoder = av.Transcoder(ouputFile)
+
+    inputFile = av.InputFile(inputFileName)
+    src_audioStream = inputFile.getProperties().getAudioProperties()[0]
+    audioStreamIndex = src_audioStream.getStreamIndex()
+    transcoder.addStream(av.InputStreamDesc(inputFileName, audioStreamIndex, 15))
+
+    transcoder.process()
+
+
+@raises(RuntimeError)
 def testAllSeveralInputsWithDifferentType():
     """
     Add one video and one audio to create one output stream.

--- a/test/pyTest/testVideoFrame.py
+++ b/test/pyTest/testVideoFrame.py
@@ -24,7 +24,7 @@ def testInvalidVideoFrameManualAllocated():
     frame = av.VideoFrame(desc, False)
 
     assert_equals(frame.isDataAllocated(), False)
-    assert_equals(frame.getSize(), 0)
+    assert_equals(frame.getDataSize(), 0)
     assert_equals(frame.getWidth(), width)
     assert_equals(frame.getHeight(), height)
     assert_equals(av.getPixelFormatName(frame.getPixelFormat()), "")
@@ -43,7 +43,7 @@ def testVideoFrame():
 
     assert_equals(frame.isDataAllocated(), True)
     assert_equals(frame.isVideoFrame(), True)
-    assert_equals(frame.getSize(), width * height * 1.5)
+    assert_equals(frame.getDataSize(), width * height * 1.5)
 
     frame.freeData()
     assert_equals(frame.isDataAllocated(), False)

--- a/test/pyTest/testVideoFrame.py
+++ b/test/pyTest/testVideoFrame.py
@@ -1,0 +1,49 @@
+from nose.tools import *
+
+from pyAvTranscoder import avtranscoder as av
+
+
+@raises(MemoryError)
+def testInvalidVideoFrameAutoAllocated():
+    """
+    Try to create an invalid VideoFrame automatically allocated.
+    """
+    desc = av.VideoFrameDesc(1920, 1080, "toto")
+    av.VideoFrame(desc)
+
+
+@raises(MemoryError)
+def testInvalidVideoFrameManualAllocated():
+    """
+    Try to create an invalid VideoFrame manually allocated.
+    """
+    width = 1920
+    height = 1080
+    pixelFormat = "titi"
+    desc = av.VideoFrameDesc(width, height, pixelFormat)
+    frame = av.VideoFrame(desc, False)
+
+    assert_equals(frame.isDataAllocated(), False)
+    assert_equals(frame.getSize(), 0)
+    assert_equals(frame.getWidth(), width)
+    assert_equals(frame.getHeight(), height)
+    assert_equals(av.getPixelFormatName(frame.getPixelFormat()), "")
+
+    frame.allocateData()
+
+def testVideoFrame():
+    """
+    Check the size and the data buffer of a VideoFrame.
+    """
+    width = 1920
+    height = 1080
+    pixelFormat = "yuv420p"
+    desc = av.VideoFrameDesc(width, height, pixelFormat)
+    frame = av.VideoFrame(desc)
+
+    assert_equals(frame.isDataAllocated(), True)
+    assert_equals(frame.isVideoFrame(), True)
+    assert_equals(frame.getSize(), width * height * 1.5)
+
+    frame.freeData()
+    assert_equals(frame.isDataAllocated(), False)

--- a/test/pyTest/testVideoReader.py
+++ b/test/pyTest/testVideoReader.py
@@ -22,7 +22,7 @@ def testVideoReaderCreateNewInputFile():
     for i in xrange(0, reader.getSourceVideoProperties().getNbFrames()):
         frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
-        assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
+        assert_equals( frame.getDataSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
     # check if there is no next frame
     frame = reader.readNextFrame()
@@ -42,7 +42,7 @@ def testVideoReaderReferenceInputFile():
     for i in xrange(0, reader.getSourceVideoProperties().getNbFrames()):
         frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
-        assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
+        assert_equals( frame.getDataSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
     # check if there is no next frame
     assert_equals( reader.readNextFrame(), None )
@@ -60,7 +60,7 @@ def testVideoReaderWithGenerator():
     for i in xrange(0, reader.getSourceVideoProperties().getNbFrames()):
         frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
-        assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
+        assert_equals( frame.getDataSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
     # check if there is no next frame
     assert_equals( reader.readNextFrame(), None )
@@ -70,4 +70,4 @@ def testVideoReaderWithGenerator():
     for i in xrange(0, 9):
         frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
-        assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
+        assert_equals( frame.getDataSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )

--- a/test/pyTest/testVideoReader.py
+++ b/test/pyTest/testVideoReader.py
@@ -1,12 +1,9 @@
 import os
 
 # Check if environment is setup to run the tests
-if os.environ.get('AVTRANSCODER_TEST_VIDEO_AVI_FILE') is None or \
-    os.environ.get('AVTRANSCODER_TEST_AUDIO_WAVE_FILE') is None:
+if os.environ.get('AVTRANSCODER_TEST_VIDEO_AVI_FILE') is None:
     from nose.plugins.skip import SkipTest
-    raise SkipTest("Need to define environment variables "
-        "AVTRANSCODER_TEST_VIDEO_AVI_FILE and "
-        "AVTRANSCODER_TEST_AUDIO_WAVE_FILE")
+    raise SkipTest("Need to define environment variables AVTRANSCODER_TEST_VIDEO_AVI_FILE")
 
 from nose.tools import *
 
@@ -51,32 +48,6 @@ def testVideoReaderReferenceInputFile():
     assert_equals( reader.readNextFrame(), None )
 
 
-def testAudioReaderChannelsExtraction():
-    """
-    Read the same audio stream with several AudioReaders.
-    Compare decoded frames from reader of all channels, and of one channel.
-    """
-    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
-    inputFile = av.InputFile(inputFileName)
-    streamIndex = inputFile.getProperties().getAudioProperties()[0].getStreamIndex()
-    channelIndex = 0
-
-    # create reader to read all channels of the audio stream
-    readerOfAllChannels = av.AudioReader(inputFile, streamIndex)
-    nbChannels = readerOfAllChannels.getOutputNbChannels()
-    # read first frame
-    frame = readerOfAllChannels.readNextFrame()
-    sizeOfFrameWithAllChannels = frame.getSize()
-
-    # create reader to read one channel of the audio stream
-    readerOfOneChannel = av.AudioReader(inputFile, streamIndex, channelIndex)
-    # read first frame
-    frame = readerOfOneChannel.readNextFrame()
-    sizeOfFrameWithOneChannels = frame.getSize()
-
-    assert_equals( sizeOfFrameWithAllChannels / nbChannels, sizeOfFrameWithOneChannels )
-
-
 def testVideoReaderWithGenerator():
     """
     Read a video stream with the VideoReader.
@@ -100,32 +71,3 @@ def testVideoReaderWithGenerator():
         frame = reader.readNextFrame()
         bytesPerPixel = reader.getOutputBitDepth() / 8
         assert_equals( frame.getSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
-
-
-def testAudioReaderWithGenerator():
-    """
-    Read an audio stream with the AudioReader.
-    When there is no more data to decode, switch to a generator and process some frames.
-    """
-    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
-    inputFile = av.InputFile(inputFileName)
-    reader = av.AudioReader(inputFile)
-
-    # read all frames and check their size
-    while True:
-        frame = reader.readNextFrame()
-        if not frame:
-            break
-        assert_greater(frame.getSize(), 0)
-
-    # check if there is no next frame
-    assert_equals( reader.readNextFrame(), None )
-
-    # generate 10 frames of silence
-    reader.continueWithGenerator()
-    for i in xrange(0, 9):
-        frame = reader.readNextFrame()
-        # assuming we generate data of 1920 samples of 2 bytes
-        nbSamplesPerChannel = 1920
-        bytesPerSample = 2
-        assert_equals(frame.getSize(), reader.getOutputNbChannels() * nbSamplesPerChannel * bytesPerSample )

--- a/tools/appveyor/python.nosetests.bat
+++ b/tools/appveyor/python.nosetests.bat
@@ -15,6 +15,7 @@ set AVTRANSCODER_TEST_VIDEO_AVI_FILE=%PWD%\avTranscoder-data/video\BigBuckBunny\
 set AVTRANSCODER_TEST_VIDEO_MP4_FILE=%PWD%\avTranscoder-data\video\BigBuckBunny\BigBuckBunny_HD.mp4
 set AVTRANSCODER_TEST_VIDEO_MOV_FILE=%PWD%\avTranscoder-data\video\BigBuckBunny\BigBuckBunny_640p_h264.mov
 set AVTRANSCODER_TEST_AUDIO_WAVE_FILE=%PWD%\avTranscoder-data\audio\frequenciesPerChannel.wav
+set AVTRANSCODER_TEST_AUDIO_WAVE_MONO_FILE=%PWD%\avTranscoder-data\audio\frequenciesOneChannel.wav
 set AVTRANSCODER_TEST_AUDIO_MOV_FILE=%PWD%\avTranscoder-data\video\BigBuckBunny\BigBuckBunny_1080p_5_1.mov
 set AVTRANSCODER_TEST_IMAGE_PNG_FILE=%PWD%\avTranscoder-data\image\BigBuckBunny\bbb-splash.thumbnail.png
 set AVTRANSCODER_TEST_IMAGE_JPG_FILE=%PWD%\avTranscoder-data\image\BigBuckBunny\title_anouncement.thumbnail.jpg

--- a/tools/travis/python.nosetests.sh
+++ b/tools/travis/python.nosetests.sh
@@ -14,6 +14,7 @@ export AVTRANSCODER_TEST_VIDEO_MP4_FILE=`pwd`/avTranscoder-data/video/BigBuckBun
 export AVTRANSCODER_TEST_VIDEO_MOV_FILE=`pwd`/avTranscoder-data/video/BigBuckBunny/BigBuckBunny_640p_h264.mov
 export AVTRANSCODER_TEST_VIDEO_RAW_FILE=`pwd`/avTranscoder-data/video/Intro/Intro_raw_1080p.h264
 export AVTRANSCODER_TEST_AUDIO_WAVE_FILE=`pwd`/avTranscoder-data/audio/frequenciesPerChannel.wav
+export AVTRANSCODER_TEST_AUDIO_WAVE_MONO_FILE=`pwd`/avTranscoder-data/audio/frequenciesOneChannel.wav
 export AVTRANSCODER_TEST_AUDIO_MOV_FILE=`pwd`/avTranscoder-data/video/BigBuckBunny/BigBuckBunny_1080p_5_1.mov
 export AVTRANSCODER_TEST_IMAGE_PNG_FILE=`pwd`/avTranscoder-data/image/BigBuckBunny/bbb-splash.thumbnail.png
 export AVTRANSCODER_TEST_IMAGE_JPG_FILE=`pwd`/avTranscoder-data/image/BigBuckBunny/title_anouncement.thumbnail.jpg


### PR DESCRIPTION
The most important parts of the code which lead to memory leaks were:
- ~~allocation of data buffers when decoding (which is the job of the decoder).~~
- ~~reference of data buffers of other frames (which can produce copy of data depending on the state of the AVFrame).~~
- ~~assignment of external data buffer in the generators.~~
