### PR TITLE
VideoProperties: fix the estimate bitrate computed by decoding the frist GOP

### DIFF
--- a/src/AvTranscoder/properties/VideoProperties.cpp
+++ b/src/AvTranscoder/properties/VideoProperties.cpp
@@ -395,7 +395,7 @@ size_t VideoProperties::getBitRate() const
     if(gopSize > 0)
     {
         const float fps = av_q2d(_formatContext->streams[_streamIndex]->avg_frame_rate);
-        return (gopFramesSize / gopSize) * 8 * fps;
+        return (gopFramesSize / gopSize) * _pixelProperties.getMaxNbBitsInChannels() * fps;
     }
     return 0;
 }


### PR DESCRIPTION
* In case of AVC High 4:2:2 Intra video stream with yuv422p10le pixels,
the maximum number of bits for a channel is 10 (not 8).
* Remove this hard-coded value.