### PR TITLE
FileProperties: fix InputFile analysis

### DIFF
--- a/src/AvTranscoder/properties/FileProperties.cpp
+++ b/src/AvTranscoder/properties/FileProperties.cpp
@@ -15,6 +15,7 @@ FileProperties::FileProperties(const InputFile& file)
     : _file(file)
     , _formatContext(&file.getFormatContext())
     , _avFormatContext(&file.getFormatContext().getAVFormatContext())
+    , _streamsProperties()
     , _videoStreams()
     , _audioStreams()
     , _dataStreams()
@@ -92,43 +93,43 @@ void FileProperties::extractStreamProperties(IProgress& progress, const EAnalyse
     }
 
     // clear streams
-    _streams.clear();
+    _streamsProperties.clear();
 
     // once the streams vectors are filled, add their references the base streams vector
     for(size_t streamIndex = 0; streamIndex < _videoStreams.size(); ++streamIndex)
     {
         const size_t videoStreamIndex = _videoStreams.at(streamIndex).getStreamIndex();
-        _streams[videoStreamIndex] = &_videoStreams.at(streamIndex);
+        _streamsProperties[videoStreamIndex] = &_videoStreams.at(streamIndex);
     }
 
     for(size_t streamIndex = 0; streamIndex < _audioStreams.size(); ++streamIndex)
     {
         const size_t audioStreamIndex = _audioStreams.at(streamIndex).getStreamIndex();
-        _streams[audioStreamIndex] = &_audioStreams.at(streamIndex);
+        _streamsProperties[audioStreamIndex] = &_audioStreams.at(streamIndex);
     }
 
     for(size_t streamIndex = 0; streamIndex < _dataStreams.size(); ++streamIndex)
     {
         const size_t dataStreamIndex = _dataStreams.at(streamIndex).getStreamIndex();
-        _streams[dataStreamIndex] = &_dataStreams.at(streamIndex);
+        _streamsProperties[dataStreamIndex] = &_dataStreams.at(streamIndex);
     }
 
     for(size_t streamIndex = 0; streamIndex < _subtitleStreams.size(); ++streamIndex)
     {
         const size_t subtitleStreamIndex = _subtitleStreams.at(streamIndex).getStreamIndex();
-        _streams[subtitleStreamIndex] = &_subtitleStreams.at(streamIndex);
+        _streamsProperties[subtitleStreamIndex] = &_subtitleStreams.at(streamIndex);
     }
 
     for(size_t streamIndex = 0; streamIndex < _attachementStreams.size(); ++streamIndex)
     {
         const size_t attachementStreamIndex = _attachementStreams.at(streamIndex).getStreamIndex();
-        _streams[attachementStreamIndex] = &_attachementStreams.at(streamIndex);
+        _streamsProperties[attachementStreamIndex] = &_attachementStreams.at(streamIndex);
     }
 
     for(size_t streamIndex = 0; streamIndex < _unknownStreams.size(); ++streamIndex)
     {
         const size_t unknownStreamIndex = _unknownStreams.at(streamIndex).getStreamIndex();
-        _streams[unknownStreamIndex] = &_unknownStreams.at(streamIndex);
+        _streamsProperties[unknownStreamIndex] = &_unknownStreams.at(streamIndex);
     }
 
     // Returns at the beginning of the stream after any deep analysis
@@ -224,7 +225,7 @@ size_t FileProperties::getPacketSize() const
 
 const avtranscoder::StreamProperties& FileProperties::getStreamPropertiesWithIndex(const size_t streamIndex) const
 {
-    avtranscoder::StreamProperties* properties = _streams.find(streamIndex)->second;
+    avtranscoder::StreamProperties* properties = _streamsProperties.find(streamIndex)->second;
     if(properties)
         return *properties;
     std::stringstream os;
@@ -236,7 +237,7 @@ const avtranscoder::StreamProperties& FileProperties::getStreamPropertiesWithInd
 const std::vector<avtranscoder::StreamProperties*> FileProperties::getStreamProperties() const
 {
     std::vector<avtranscoder::StreamProperties*> streams;
-    for(std::map<size_t, StreamProperties*>::const_iterator it = _streams.begin(); it != _streams.end(); ++it)
+    for(std::map<size_t, StreamProperties*>::const_iterator it = _streamsProperties.begin(); it != _streamsProperties.end(); ++it)
     {
         streams.push_back(it->second);
     }

--- a/src/AvTranscoder/properties/FileProperties.cpp
+++ b/src/AvTranscoder/properties/FileProperties.cpp
@@ -228,10 +228,10 @@ const avtranscoder::StreamProperties& FileProperties::getStreamPropertiesWithInd
     avtranscoder::StreamProperties* properties = _streamsProperties.find(streamIndex)->second;
     if(properties)
         return *properties;
-    std::stringstream os;
-    os << "No stream properties correspond to stream at index ";
-    os << streamIndex;
-    throw std::runtime_error(os.str());
+    std::stringstream msg;
+    msg << "No stream properties correspond to stream at index ";
+    msg << streamIndex;
+    throw std::runtime_error(msg.str());
 }
 
 const std::vector<avtranscoder::StreamProperties*> FileProperties::getStreamProperties() const

--- a/src/AvTranscoder/properties/FileProperties.cpp
+++ b/src/AvTranscoder/properties/FileProperties.cpp
@@ -36,7 +36,12 @@ void FileProperties::extractStreamProperties(IProgress& progress, const EAnalyse
         const_cast<InputFile&>(_file).seekAtFrame(0, AVSEEK_FLAG_BACKWARD);
 
     // clear properties
-    clearStreamProperties();
+    _videoStreams.clear();
+    _audioStreams.clear();
+    _dataStreams.clear();
+    _subtitleStreams.clear();
+    _attachementStreams.clear();
+    _unknownStreams.clear();
 
     // reload properties
     for(size_t streamIndex = 0; streamIndex < _formatContext->getNbStreams(); ++streamIndex)
@@ -85,6 +90,9 @@ void FileProperties::extractStreamProperties(IProgress& progress, const EAnalyse
             }
         }
     }
+
+    // clear streams
+    _streams.clear();
 
     // once the streams vectors are filled, add their references the base streams vector
     for(size_t streamIndex = 0; streamIndex < _videoStreams.size(); ++streamIndex)
@@ -371,18 +379,6 @@ std::string FileProperties::allPropertiesAsJson() const
         writer << std::make_pair("unknown", unknown.build());
     }
     return writer.build();
-}
-
-void FileProperties::clearStreamProperties()
-{
-    _streams.clear();
-
-    _videoStreams.clear();
-    _audioStreams.clear();
-    _dataStreams.clear();
-    _subtitleStreams.clear();
-    _attachementStreams.clear();
-    _unknownStreams.clear();
 }
 
 std::ostream& operator<<(std::ostream& flux, const FileProperties& fileProperties)

--- a/src/AvTranscoder/properties/FileProperties.hpp
+++ b/src/AvTranscoder/properties/FileProperties.hpp
@@ -107,8 +107,6 @@ private:
     }
 #endif
 
-    void clearStreamProperties(); ///< Clear all array of stream properties
-
 private:
     const InputFile& _file; ///< Has link (no ownership)
     const FormatContext* _formatContext;     ///< Has link (no ownership)

--- a/src/AvTranscoder/properties/FileProperties.hpp
+++ b/src/AvTranscoder/properties/FileProperties.hpp
@@ -113,7 +113,7 @@ private:
     const AVFormatContext* _avFormatContext; ///< Has link (no ownership)
 
     std::map<size_t, StreamProperties*>
-        _streams; ///< Map of properties per stream index (of all types) - only references to the following properties
+        _streamsProperties; ///< Map of properties per stream index (of all types) - only references to the following properties
 
     std::vector<VideoProperties> _videoStreams;             ///< Array of properties per video stream
     std::vector<AudioProperties> _audioStreams;             ///< Array of properties per audio stream


### PR DESCRIPTION
* When manually analyse an InputFile, the previous StreamProperties created are used to access the codec (if decoding is needed).
* So in that cases, the _streams vector should be cleared after the new analysis.