### PR TITLE
InputFile: throw a runtime_error if there is an error while reading the next packet

### DIFF
--- a/src/AvTranscoder/file/InputFile.cpp
+++ b/src/AvTranscoder/file/InputFile.cpp
@@ -62,8 +62,15 @@ bool InputFile::readNextPacket(CodedData& data, const size_t streamIndex)
         if(ret < 0) // error or end of file
         {
             LOG_INFO("Stop reading the next frame of file '" << _filename << "', stream " << streamIndex << " ("
-                                                             << getDescriptionFromErrorCode(ret) << ")")
-            return false;
+                                                             << getDescriptionFromErrorCode(ret) << ")");
+            if(ret == AVERROR_EOF)
+            {
+                LOG_INFO("There is no more data to read.");
+                return false;
+            }
+
+            LOG_ERROR("Error while reading this stream.");
+            throw std::runtime_error("Error while reading this stream.");
         }
 
         // Add Stream info to the packet

--- a/src/AvTranscoder/file/InputFile.hpp
+++ b/src/AvTranscoder/file/InputFile.hpp
@@ -43,7 +43,8 @@ public:
     /**
      * @brief Read the next packet of the specified stream
      * @param data: data of next packet read
-     * @return if next packet was read succefully
+     * @return if next packet was read successfully
+     * @exception runtime_error launched if there is an error (other than End Of File) while reading the next packet
      **/
     bool readNextPacket(CodedData& data, const size_t streamIndex);
 


### PR DESCRIPTION
The error has to be other than the End Of the File.