### PR TITLE
VideoDecoder: add a warning msg when trying to extract a video channel

### DIFF
--- a/src/AvTranscoder/decoder/VideoDecoder.cpp
+++ b/src/AvTranscoder/decoder/VideoDecoder.cpp
@@ -117,6 +117,7 @@ bool VideoDecoder::decodeNextFrame(IFrame& frameBuffer)
 
 bool VideoDecoder::decodeNextFrame(IFrame& frameBuffer, const std::vector<size_t> channelIndexArray)
 {
+    LOG_WARN("Decoding of a specific video channel is not supported.");
     return false;
 }
 


### PR DESCRIPTION
Because this feature is not supported... Yet!