### PR TITLE
Video/AudioDecoder: fix the codec state when calling decoder destructor

### DIFF
--- a/src/AvTranscoder/codec/ICodec.cpp
+++ b/src/AvTranscoder/codec/ICodec.cpp
@@ -44,7 +44,7 @@ ICodec::ICodec(const ECodecType type, AVCodecContext& avCodecContext)
 
 ICodec::~ICodec()
 {
-    avcodec_close(_avCodecContext);
+    closeCodec();
 
     if(!_isCodecContextAllocated)
         return;
@@ -73,12 +73,19 @@ void ICodec::openCodec()
             msg += ") ";
         }
 
-        avcodec_close(_avCodecContext);
+        closeCodec();
 
         msg += getDescriptionFromErrorCode(ret);
 
         throw std::runtime_error(msg);
     }
+}
+
+void ICodec::closeCodec()
+{
+    if(!_avCodecContext)
+        throw std::runtime_error("Unable to close a codec without codec context");
+    avcodec_close(_avCodecContext);
 }
 
 std::string ICodec::getCodecName() const

--- a/src/AvTranscoder/codec/ICodec.cpp
+++ b/src/AvTranscoder/codec/ICodec.cpp
@@ -44,8 +44,6 @@ ICodec::ICodec(const ECodecType type, AVCodecContext& avCodecContext)
 
 ICodec::~ICodec()
 {
-    closeCodec();
-
     if(!_isCodecContextAllocated)
         return;
 

--- a/src/AvTranscoder/codec/ICodec.hpp
+++ b/src/AvTranscoder/codec/ICodec.hpp
@@ -37,6 +37,8 @@ public:
 
     /// Initialize the codec context.
     void openCodec();
+    /// Reset the codec context.
+    void closeCodec();
 
     std::string getCodecName() const;
     AVCodecID getCodecId() const;

--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -27,6 +27,8 @@ AudioDecoder::AudioDecoder(InputStream& inputStream)
 
 AudioDecoder::~AudioDecoder()
 {
+    if(_isSetup)
+        _inputStream->getAudioCodec().closeCodec();
 }
 
 void AudioDecoder::setupDecoder(const ProfileLoader::Profile& profile)
@@ -73,7 +75,7 @@ void AudioDecoder::setupDecoder(const ProfileLoader::Profile& profile)
     }
 
     // open decoder
-    _inputStream->getAudioCodec().openCodec();
+    codec.openCodec();
     _isSetup = true;
 }
 

--- a/src/AvTranscoder/decoder/VideoDecoder.cpp
+++ b/src/AvTranscoder/decoder/VideoDecoder.cpp
@@ -24,6 +24,8 @@ VideoDecoder::VideoDecoder(InputStream& inputStream)
 
 VideoDecoder::~VideoDecoder()
 {
+    if(_isSetup)
+        _inputStream->getVideoCodec().closeCodec();
 }
 
 void VideoDecoder::setupDecoder(const ProfileLoader::Profile& profile)
@@ -70,7 +72,7 @@ void VideoDecoder::setupDecoder(const ProfileLoader::Profile& profile)
     }
 
     // open decoder
-    _inputStream->getVideoCodec().openCodec();
+    codec.openCodec();
     _isSetup = true;
 }
 

--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -25,12 +25,12 @@ Transcoder::Transcoder(IOutputFile& outputFile)
 
 Transcoder::~Transcoder()
 {
-    for(std::vector<InputFile*>::iterator it = _inputFiles.begin(); it != _inputFiles.end(); ++it)
+    for(std::vector<StreamTranscoder*>::iterator it = _streamTranscodersAllocated.begin();
+        it != _streamTranscodersAllocated.end(); ++it)
     {
         delete(*it);
     }
-    for(std::vector<StreamTranscoder*>::iterator it = _streamTranscodersAllocated.begin();
-        it != _streamTranscodersAllocated.end(); ++it)
+    for(std::vector<InputFile*>::iterator it = _inputFiles.begin(); it != _inputFiles.end(); ++it)
     {
         delete(*it);
     }

--- a/test/pyTest/testAudioReader.py
+++ b/test/pyTest/testAudioReader.py
@@ -55,6 +55,10 @@ def testAudioReaderChannelsExtraction():
 
     assert_equals( sizeOfFrameWithAllChannels / nbChannels, sizeOfFrameWithOneChannels )
 
+    # Force to call the readers destructor before the inputFile destructor (which cannot happen in C++)
+    readerOfAllChannels = None
+    readerOfOneChannel = None
+
 
 def testAudioReaderWithGenerator():
     """
@@ -62,8 +66,7 @@ def testAudioReaderWithGenerator():
     When there is no more data to decode, switch to a generator and process some frames.
     """
     inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
-    inputFile = av.InputFile(inputFileName)
-    reader = av.AudioReader(inputFile)
+    reader = av.AudioReader(inputFileName)
 
     # read all frames and check their size
     while True:

--- a/test/pyTest/testVideoReader.py
+++ b/test/pyTest/testVideoReader.py
@@ -25,7 +25,6 @@ def testVideoReaderCreateNewInputFile():
         assert_equals( frame.getDataSize(), reader.getOutputWidth() * reader.getOutputHeight() * bytesPerPixel )
 
     # check if there is no next frame
-    frame = reader.readNextFrame()
     assert_equals( reader.readNextFrame(), None )
 
 
@@ -46,6 +45,9 @@ def testVideoReaderReferenceInputFile():
 
     # check if there is no next frame
     assert_equals( reader.readNextFrame(), None )
+
+    # Force to call the reader destructor before the inputFile destructor (which cannot happen in C++)
+    reader = None
 
 
 def testVideoReaderWithGenerator():


### PR DESCRIPTION
This PR fixes our paddef issue XDMAT-525.