### PR TITLE
The format specific options are passed as arguments to the file header writing function

### DIFF
--- a/src/AvTranscoder/file/OutputFile.hpp
+++ b/src/AvTranscoder/file/OutputFile.hpp
@@ -117,7 +117,7 @@ private:
      * @see setupWrapping
      * @see beginWrap
      */
-    ProfileLoader::Profile _profile;
+    AVDictionary* _profileOptions;
 };
 }
 


### PR DESCRIPTION
Some file format headers depend on format specific options, so these options must be set to the format context before the file header is written.
This is done into the [avformat_write_header](https://www.ffmpeg.org/doxygen/2.7/mux_8c_source.html#l00428) method, through the call of the [init_muxer](https://www.ffmpeg.org/doxygen/2.7/mux_8c_source.html#l00235) function.