### PR TITLE
Fix: different frame size as inputs of the filter graph

### DIFF
--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -44,7 +44,7 @@ void FilterGraph::process(const std::vector<IFrame*>& inputs, IFrame& output)
     // setup input frames
     for(size_t index = 0; index < inputs.size(); ++index)
     {
-        const int ret = av_buffersrc_write_frame(_filters.at(index)->getAVFilterContext(), &inputs.at(index)->getAVFrame());
+        const int ret = av_buffersrc_add_frame_flags(_filters.at(index)->getAVFilterContext(), &inputs.at(index)->getAVFrame(), AV_BUFFERSRC_FLAG_PUSH);
         if(ret < 0)
         {
             throw std::runtime_error("Error when adding a frame to the source buffer used to start to process filters: " +

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -18,11 +18,11 @@ namespace avtranscoder
 
 /******************
 
-    AudioFramebuffer
+    AudioFrameBuffer
 
  ******************/
 
-AudioFramebuffer::AudioFramebuffer(const AudioFrameDesc& audioFrameDesc)
+AudioFrameBuffer::AudioFrameBuffer(const AudioFrameDesc& audioFrameDesc)
     : _audioFrameDesc(audioFrameDesc)
     , _frameQueue()
     , _totalDataSize(0)
@@ -30,13 +30,13 @@ AudioFramebuffer::AudioFramebuffer(const AudioFrameDesc& audioFrameDesc)
 {
 }
 
-AudioFramebuffer::~AudioFramebuffer()
+AudioFrameBuffer::~AudioFrameBuffer()
 {
     for(size_t i = 0; i < _frameQueue.size(); ++i)
         popFrame();
 }
 
-void AudioFramebuffer::addFrame(IFrame* frame)
+void AudioFrameBuffer::addFrame(IFrame* frame)
 {
     LOG_DEBUG("Add a new " << frame->getDataSize() << " bytes frame to frame buffer. New buffer size: " << _frameQueue.size() + 1);
     // Copy the input frame to store it into the queue
@@ -50,13 +50,13 @@ void AudioFramebuffer::addFrame(IFrame* frame)
     _frameQueue.push(newAudioFrame);
 }
 
-void AudioFramebuffer::popFrame()
+void AudioFrameBuffer::popFrame()
 {
     _frameQueue.pop();
     LOG_DEBUG("Pop frame from buffer. Remaining frames in buffer: " << _frameQueue.size());
 }
 
-IFrame* AudioFramebuffer::getFrame(const size_t size)
+IFrame* AudioFrameBuffer::getFrame(const size_t size)
 {
     LOG_DEBUG("Get a " << size << " bytes frame from a " << _totalDataSize << " bytes frame buffer");
     IFrame* next = _frameQueue.front();
@@ -169,7 +169,7 @@ bool FilterGraph::hasBufferedFrames()
     if(!_inputAudioFrameBuffers.size())
         return false;
 
-    for(std::vector<AudioFramebuffer>::iterator it = _inputAudioFrameBuffers.begin(); it != _inputAudioFrameBuffers.end(); ++it)
+    for(std::vector<AudioFrameBuffer>::iterator it = _inputAudioFrameBuffers.begin(); it != _inputAudioFrameBuffers.end(); ++it)
     {
         if(it->isEmpty())
             return false;
@@ -204,7 +204,7 @@ bool FilterGraph::areFrameBuffersEmpty()
     if(!_inputAudioFrameBuffers.size())
         return true;
 
-    for(std::vector<AudioFramebuffer>::iterator it = _inputAudioFrameBuffers.begin(); it != _inputAudioFrameBuffers.end(); ++it)
+    for(std::vector<AudioFrameBuffer>::iterator it = _inputAudioFrameBuffers.begin(); it != _inputAudioFrameBuffers.end(); ++it)
     {
         if(!it->isEmpty())
             return false;
@@ -356,7 +356,7 @@ void FilterGraph::addInBuffer(const std::vector<IFrame*>& inputs)
             const AudioFrameDesc audioFrameDesc(audioFrame->getSampleRate(),
                                                 audioFrame->getNbChannels(),
                                                 getSampleFormatName(audioFrame->getSampleFormat()));
-            _inputAudioFrameBuffers.push_back(AudioFramebuffer(audioFrameDesc));
+            _inputAudioFrameBuffers.push_back(AudioFrameBuffer(audioFrameDesc));
         }
         // video frame
         else if((*it)->isVideoFrame())

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -140,7 +140,8 @@ size_t FilterGraph::getMinInputFrameSize(const std::vector<IFrame*>& inputs)
     int minFrameSize = inputs.at(0)->getDataSize();
     for(size_t index = 1; index < inputs.size(); ++index)
     {
-        if(minFrameSize > inputs.at(index)->getDataSize())
+        // if the input frame is shorter, and if there is no data enough into the corresponding frame buffer
+        if(minFrameSize > inputs.at(index)->getDataSize() && minFrameSize > _inputFramesBuffer.at(index).getDataSize())
             minFrameSize = inputs.at(index)->getDataSize();
     }
     return minFrameSize;

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -356,7 +356,7 @@ void FilterGraph::addInBuffer(const std::vector<IFrame*>& inputs)
             const AudioFrameDesc audioFrameDesc(audioFrame->getSampleRate(),
                                                 audioFrame->getNbChannels(),
                                                 getSampleFormatName(audioFrame->getSampleFormat()));
-            _inputAudioFrameBuffers.push_back(AudioFrameBuffer(audioFrameDesc));
+            _inputAudioFrameBuffers.insert(_inputAudioFrameBuffers.begin(), AudioFrameBuffer(audioFrameDesc));
         }
         // video frame
         else if((*it)->isVideoFrame())

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -132,17 +132,25 @@ FilterGraph::~FilterGraph()
     avfilter_graph_free(&_graph);
 }
 
+size_t FilterGraph::getAvailableFrameSize(const std::vector<IFrame*>& inputs, const size_t& index)
+{
+    size_t frameSize = inputs.at(index)->getDataSize();
+    if(frameSize == 0)
+        frameSize = _inputFramesBuffer.at(index).getDataSize();
+    return frameSize;
+}
+
 size_t FilterGraph::getMinInputFrameSize(const std::vector<IFrame*>& inputs)
 {
     if(!inputs.size())
         return 0;
 
-    int minFrameSize = inputs.at(0)->getDataSize();
+    size_t minFrameSize = getAvailableFrameSize(inputs, 0);
     for(size_t index = 1; index < inputs.size(); ++index)
     {
-        // if the input frame is shorter, and if there is no data enough into the corresponding frame buffer
-        if(minFrameSize > inputs.at(index)->getDataSize() && minFrameSize > _inputFramesBuffer.at(index).getDataSize())
-            minFrameSize = inputs.at(index)->getDataSize();
+        const size_t availableFrameSize = getAvailableFrameSize(inputs, index);
+        if(minFrameSize > availableFrameSize)
+            minFrameSize = availableFrameSize;
     }
     return minFrameSize;
 }

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -32,7 +32,7 @@ FrameBuffer::FrameBuffer(const AudioFrameDesc& audioFrameDesc)
 
 FrameBuffer::~FrameBuffer()
 {
-    for (int i = 0; i < _frameQueue.size(); ++i)
+    for(size_t i = 0; i < _frameQueue.size(); ++i)
         popFrame();
 }
 

--- a/src/AvTranscoder/filter/FilterGraph.cpp
+++ b/src/AvTranscoder/filter/FilterGraph.cpp
@@ -38,7 +38,7 @@ FrameBuffer::~FrameBuffer()
 
 void FrameBuffer::addFrame(IFrame* frame)
 {
-    LOG_DEBUG("Add a new frame to frame buffer. New buffer size: " << _frameQueue.size() + 1);
+    LOG_DEBUG("Add a new " << frame->getDataSize() << " bytes frame to frame buffer. New buffer size: " << _frameQueue.size() + 1);
     // Copy the input frame to store it into the queue
     AudioFrame* newAudioFrame = new AudioFrame(_audioFrameDesc, false);
     const size_t expectedNbSamples = frame->getDataSize() / (newAudioFrame->getNbChannels() * newAudioFrame->getBytesPerSample());

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -5,13 +5,58 @@
 #include <AvTranscoder/filter/Filter.hpp>
 #include <AvTranscoder/codec/ICodec.hpp>
 #include <AvTranscoder/data/decoded/IFrame.hpp>
+#include <AvTranscoder/data/decoded/AudioFrame.hpp>
 
 #include <vector>
+#include <queue>
 
 struct AVFilterGraph;
 
 namespace avtranscoder
 {
+
+/**
+ * @brief Filter graph input frame buffer.
+ * This FIFO buffer contains IFrame pointers and can deliver specific size frames.
+ *
+ * @todo Only for audio frame, for the moment. Make it usable with video frames.
+ **/
+class FrameBuffer
+{
+public:
+    FrameBuffer(const AudioFrameDesc& audioFrameDesc);
+    ~FrameBuffer();
+
+    /**
+     * @brief Return whether the buffer is empty or not.
+     */
+    bool isEmpty() { return _frameQueue.empty() && _totalDataSize == 0; }
+    /**
+     * @brief Return the total amount of data contained in the frames of the buffer.
+     */
+    size_t getDataSize() { return _totalDataSize; }
+
+    /**
+     * @brief Push a frame at the end of the buffer.
+     */
+    void addFrame(IFrame* frame);
+
+    /**
+     * @brief Retrieve a IFrame pointer of the specified size, from the beginning of the buffer.
+     * If no size is specified, the whole first IFrame pointer is returned.
+     */
+    IFrame* getFrame(const size_t size = 0);
+
+private:
+    void popFrame();
+
+    const AudioFrameDesc _audioFrameDesc;
+
+    std::queue<IFrame*> _frameQueue;
+    size_t _totalDataSize;
+    size_t _positionInFrontFrame;
+
+};
 
 /**
  * @brief Manager of filters.

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -32,7 +32,7 @@ public:
      */
     bool isEmpty() const { return _frameQueue.empty() && _totalDataSize == 0; }
     /**
-     * @brief Return the total amount of data contained in the frames of the buffer.
+     * @brief Return the total amount of available data contained in the frames of the buffer.
      */
     size_t getDataSize() const { return _totalDataSize; }
     /**

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -21,7 +21,7 @@ namespace avtranscoder
  * It makes no sense to use such buffers for video, since video frames are spatially consistent,
  * so can not be divided nor concatenated.
  **/
-class AudioFrameBuffer
+class AvExport AudioFrameBuffer
 {
 public:
     AudioFrameBuffer(const AudioFrameDesc& audioFrameDesc);

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -127,10 +127,14 @@ private:
     void addOutBuffer(const IFrame& output);
     //@}
 
+    size_t getMinInputFrameSize(const std::vector<IFrame*>& inputs);
+
 private:
     AVFilterGraph* _graph;         ///< The graph which holds the filters.
     std::vector<Filter*> _filters; ///< List of filters to process.
     const ICodec& _codec;          ///< Codec of the stream on which the filters will be applied.
+
+    std::vector<FrameBuffer> _inputFramesBuffer;
 
     /**
      * @brief Is the FilterGraph initialized.

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -16,16 +16,16 @@ namespace avtranscoder
 {
 
 /**
- * @brief Filter graph input frame buffer.
- * This FIFO buffer contains IFrame pointers and can deliver specific size frames.
- *
- * @todo Only for audio frame, for the moment. Make it usable with video frames.
+ * @brief Filter graph input audio frame buffer.
+ * This FIFO buffer contains IFrame pointers and can deliver specific size audio frames.
+ * It makes no sense to use such buffers for video, since video frames are spatially consistent,
+ * so can not be divided nor concatenated.
  **/
-class FrameBuffer
+class AudioFramebuffer
 {
 public:
-    FrameBuffer(const AudioFrameDesc& audioFrameDesc);
-    ~FrameBuffer();
+    AudioFramebuffer(const AudioFrameDesc& audioFrameDesc);
+    ~AudioFramebuffer();
 
     /**
      * @brief Return whether the buffer is empty or not.
@@ -143,7 +143,8 @@ private:
      */
     size_t getMinInputFrameSize(const std::vector<IFrame*>& inputs);
 
-    bool areInputFrameSizeEqual(const std::vector<IFrame*>& inputs);
+    bool areInputAudioFrames(const std::vector<IFrame*>& inputs);
+    bool areInputFrameSizesEqual(const std::vector<IFrame*>& inputs);
     bool areFrameBuffersEmpty();
 
 private:
@@ -151,7 +152,7 @@ private:
     std::vector<Filter*> _filters; ///< List of filters to process.
     const ICodec& _codec;          ///< Codec of the stream on which the filters will be applied.
 
-    std::vector<FrameBuffer> _inputFramesBuffer;
+    std::vector<AudioFramebuffer> _inputAudioFramesBuffer;
 
     /**
      * @brief Is the FilterGraph initialized.

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -39,6 +39,10 @@ public:
      * @brief Return the number of frames contained in the buffer.
      */
     size_t getBufferSize() const { return _frameQueue.size(); }
+    /**
+     * @brief Return the number of bytes by sample from the internal AudioFrameDesc.
+     */
+    size_t getBytesPerSample();
 
     /**
      * @brief Push a frame at the end of the buffer.
@@ -50,6 +54,7 @@ public:
      * If no size is specified, the whole first IFrame pointer is returned.
      */
     IFrame* getFrame(const size_t size = 0);
+    IFrame* getFrameSampleNb(const size_t sampleNb);
 
 private:
     void popFrame();
@@ -138,10 +143,11 @@ private:
      * @brief Return the input frame size if not null, or the available size into the corresponding frame buffer
      */
     size_t getAvailableFrameSize(const std::vector<IFrame*>& inputs, const size_t& index);
+    size_t getAvailableFrameSamplesNb(const std::vector<IFrame*>& inputs, const size_t& index);
     /**
-     * @brief Get the minimum size between input frames, or available frame buffers
+     * @brief Get the minimum samples number between input frames, or available frame buffers
      */
-    size_t getMinInputFrameSize(const std::vector<IFrame*>& inputs);
+    size_t getMinInputFrameSamplesNb(const std::vector<IFrame*>& inputs);
 
     bool areInputFrameSizesEqual(const std::vector<IFrame*>& inputs);
     bool areFrameBuffersEmpty();

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -35,6 +35,10 @@ public:
      * @brief Return the total amount of data contained in the frames of the buffer.
      */
     size_t getDataSize() const { return _totalDataSize; }
+    /**
+     * @brief Return the number of frames contained in the buffer.
+     */
+    size_t getBufferSize() const { return _frameQueue.size(); }
 
     /**
      * @brief Push a frame at the end of the buffer.
@@ -106,6 +110,9 @@ public:
      * @return If at least one filter has been added to the filter graph
      */
     bool hasFilters() const { return !_filters.empty(); }
+
+    bool hasBufferedFrames();
+    bool hasBufferedFrames(const size_t index);
 
 private:
     /**

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -30,11 +30,11 @@ public:
     /**
      * @brief Return whether the buffer is empty or not.
      */
-    bool isEmpty() { return _frameQueue.empty() && _totalDataSize == 0; }
+    bool isEmpty() const { return _frameQueue.empty() && _totalDataSize == 0; }
     /**
      * @brief Return the total amount of data contained in the frames of the buffer.
      */
-    size_t getDataSize() { return _totalDataSize; }
+    size_t getDataSize() const { return _totalDataSize; }
 
     /**
      * @brief Push a frame at the end of the buffer.
@@ -50,7 +50,7 @@ public:
 private:
     void popFrame();
 
-    const AudioFrameDesc _audioFrameDesc;
+    AudioFrameDesc _audioFrameDesc;
 
     std::queue<IFrame*> _frameQueue;
     size_t _totalDataSize;

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -21,11 +21,11 @@ namespace avtranscoder
  * It makes no sense to use such buffers for video, since video frames are spatially consistent,
  * so can not be divided nor concatenated.
  **/
-class AudioFramebuffer
+class AudioFrameBuffer
 {
 public:
-    AudioFramebuffer(const AudioFrameDesc& audioFrameDesc);
-    ~AudioFramebuffer();
+    AudioFrameBuffer(const AudioFrameDesc& audioFrameDesc);
+    ~AudioFrameBuffer();
 
     /**
      * @brief Return whether the buffer is empty or not.
@@ -151,7 +151,7 @@ private:
     std::vector<Filter*> _filters; ///< List of filters to process.
     const ICodec& _codec;          ///< Codec of the stream on which the filters will be applied.
 
-    std::vector<AudioFramebuffer> _inputAudioFrameBuffers;
+    std::vector<AudioFrameBuffer> _inputAudioFrameBuffers;
 
     /**
      * @brief Is the FilterGraph initialized.

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -127,7 +127,15 @@ private:
     void addOutBuffer(const IFrame& output);
     //@}
 
+    /**
+     * @brief Return the input frame size if not null, or the available size into the corresponding frame buffer
+     */
+    size_t getAvailableFrameSize(const std::vector<IFrame*>& inputs, const size_t& index);
+    /**
+     * @brief Get the minimum size between input frames, or available frame buffers
+     */
     size_t getMinInputFrameSize(const std::vector<IFrame*>& inputs);
+
     bool areInputFrameSizeEqual(const std::vector<IFrame*>& inputs);
     bool areFrameBuffersEmpty();
 

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -128,6 +128,8 @@ private:
     //@}
 
     size_t getMinInputFrameSize(const std::vector<IFrame*>& inputs);
+    bool areInputFrameSizeEqual(const std::vector<IFrame*>& inputs);
+    bool areFrameBuffersEmpty();
 
 private:
     AVFilterGraph* _graph;         ///< The graph which holds the filters.

--- a/src/AvTranscoder/filter/FilterGraph.hpp
+++ b/src/AvTranscoder/filter/FilterGraph.hpp
@@ -143,7 +143,6 @@ private:
      */
     size_t getMinInputFrameSize(const std::vector<IFrame*>& inputs);
 
-    bool areInputAudioFrames(const std::vector<IFrame*>& inputs);
     bool areInputFrameSizesEqual(const std::vector<IFrame*>& inputs);
     bool areFrameBuffersEmpty();
 
@@ -152,7 +151,7 @@ private:
     std::vector<Filter*> _filters; ///< List of filters to process.
     const ICodec& _codec;          ///< Codec of the stream on which the filters will be applied.
 
-    std::vector<AudioFramebuffer> _inputAudioFramesBuffer;
+    std::vector<AudioFramebuffer> _inputAudioFrameBuffers;
 
     /**
      * @brief Is the FilterGraph initialized.

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -579,7 +579,7 @@ bool StreamTranscoder::processTranscode()
             if(!_filterGraph->hasFilters() || !_filterGraph->hasBufferedFrames(index))
             {
                 continueProcess = false;
-                continue;
+                break;
             }
             LOG_DEBUG("Some frames remain into filter graph buffer " << index);
 

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -582,6 +582,11 @@ bool StreamTranscoder::processTranscode()
                 continue;
             }
             LOG_DEBUG("Some frames remain into filter graph buffer " << index);
+
+            // Reset the non-decoded data as an empty frame
+            _decodedData.at(index)->freeData();
+            _decodedData.at(index)->getAVFrame().format = -1;
+            _decodedData.at(index)->getAVFrame().nb_samples = 0;
         }
     }
 

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -533,7 +533,7 @@ bool StreamTranscoder::processTranscode()
 
     // Decode
     LOG_DEBUG("Decode next frame")
-    bool decodingStatus = true;
+    std::vector<bool> decodingStatus(_generators.size(), true);
     for(size_t index = 0; index < _generators.size(); ++index)
     {
         if(getProcessCase() == eProcessCaseTranscode)
@@ -542,15 +542,17 @@ bool StreamTranscoder::processTranscode()
             _currentDecoder = _generators.at(index);
 
         if(! _inputStreamDesc.empty() && _inputStreamDesc.at(index).demultiplexing())
-            decodingStatus = decodingStatus && _currentDecoder->decodeNextFrame(*_decodedData.at(index), _inputStreamDesc.at(index)._channelIndexArray);
+            decodingStatus.at(index) = decodingStatus.at(index) && _currentDecoder->decodeNextFrame(*_decodedData.at(index), _inputStreamDesc.at(index)._channelIndexArray);
         else
-            decodingStatus = decodingStatus && _currentDecoder->decodeNextFrame(*_decodedData.at(index));
+            decodingStatus.at(index) = decodingStatus.at(index) && _currentDecoder->decodeNextFrame(*_decodedData.at(index));
     }
 
     // check the next data buffers in case of audio frames
     if(_decodedData.at(0)->isAudioFrame())
     {
         const int nbInputSamplesPerChannel = _decodedData.at(0)->getAVFrame().nb_samples;
+
+        // Reallocate output frame
         if(nbInputSamplesPerChannel > _filteredData->getAVFrame().nb_samples)
         {
             LOG_WARN("The buffer of filtered data corresponds to a frame of " << _filteredData->getAVFrame().nb_samples << " samples. The decoded buffer contains " << nbInputSamplesPerChannel << " samples. Reallocate it.")
@@ -569,7 +571,21 @@ bool StreamTranscoder::processTranscode()
 
     // Transform
     CodedData data;
-    if(decodingStatus)
+    bool continueProcess = true;
+    for(size_t index = 0; index < decodingStatus.size(); ++index)
+    {
+        if(!decodingStatus.at(index))
+        {
+            if(!_filterGraph->hasFilters() || !_filterGraph->hasBufferedFrames(index))
+            {
+                continueProcess = false;
+                continue;
+            }
+            LOG_DEBUG("Some frames remain into filter graph buffer " << index);
+        }
+    }
+
+    if(continueProcess)
     {
         IFrame* dataToTransform = NULL;
         if(_filterGraph->hasFilters())

--- a/test/pyTest/testMuxAudioChannels.py
+++ b/test/pyTest/testMuxAudioChannels.py
@@ -48,9 +48,13 @@ def testMuxAudioChannelsFromDifferentFormatInputs_20():
 
     assert_equals(min_src_duration, audioStat.getDuration())
 
-    # check dst audio streams
+    # check dst file properties
     dst_inputFile = av.InputFile(outputFileName)
-    dst_audioProperties = dst_inputFile.getProperties().getAudioProperties()
+    dst_fileProperties = dst_inputFile.getProperties()
+    assert_equals(min_src_duration, dst_fileProperties.getDuration())
+
+    # check dst audio streams
+    dst_audioProperties = dst_fileProperties.getAudioProperties()
     assert_equals(1, len(dst_audioProperties))
     assert_equals(2, dst_audioProperties[0].getNbChannels())
 
@@ -94,8 +98,12 @@ def testMuxAudioChannelsFromDifferentFormatInputs_51():
 
     assert_equals(min_src_duration, audioStat.getDuration())
 
-    # check dst audio streams
+    # check dst file properties
     dst_inputFile = av.InputFile(outputFileName)
+    dst_fileProperties = dst_inputFile.getProperties()
+    assert_equals(min_src_duration, dst_fileProperties.getDuration())
+
+    # check dst audio streams
     dst_audioProperties = dst_inputFile.getProperties().getAudioProperties()
     assert_equals(1, len(dst_audioProperties))
     assert_equals(6, dst_audioProperties[0].getNbChannels())

--- a/test/pyTest/testMuxAudioChannels.py
+++ b/test/pyTest/testMuxAudioChannels.py
@@ -1,0 +1,101 @@
+import os
+
+ # Check if environment is setup to run the tests
+if os.environ.get('AVTRANSCODER_TEST_AUDIO_WAVE_FILE') is None or \
+    os.environ.get('AVTRANSCODER_TEST_AUDIO_MOV_FILE') is None:
+    from nose.plugins.skip import SkipTest
+    raise SkipTest("Need to define environment variables "
+        "AVTRANSCODER_TEST_AUDIO_WAVE_FILE and "
+        "AVTRANSCODER_TEST_AUDIO_MOV_FILE")
+
+from nose.tools import *
+
+from pyAvTranscoder import avtranscoder as av
+
+def testMuxAudioChannelsFromDifferentFormatInputs_20():
+    """
+    Mux audio channels from different formats files, and generate one audio stereo stream
+    """
+    # inputs
+    inputFileName1 = os.environ['AVTRANSCODER_TEST_AUDIO_MOV_FILE']
+    inputFileName2 = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    assert_not_equals(inputFileName1, inputFileName2)
+
+    inputs = av.InputStreamDescVector()
+    inputs.append(av.InputStreamDesc(inputFileName1, 1, 1))
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 2))
+
+    # output
+    outputFileName = "testMuxAudioChannelsFromDifferentFormatInputs_20.wav"
+    ouputFile = av.OutputFile(outputFileName)
+
+    transcoder = av.Transcoder(ouputFile)
+    transcoder.addStream(inputs, "wave24b48kstereo")
+
+    progress = av.ConsoleProgress()
+    processStat = transcoder.process( progress )
+
+    # check process stat returned
+    audioStat = processStat.getAudioStat(0)
+
+    inputFile1 = av.InputFile(inputFileName1)
+    inputFile2 = av.InputFile(inputFileName2)
+
+    src_audioStream1 = inputFile1.getProperties().getAudioProperties()[0]
+    src_audioStream2 = inputFile2.getProperties().getAudioProperties()[0]
+
+    min_src_duration = min(src_audioStream1.getDuration(), src_audioStream2.getDuration())
+
+    assert_equals(min_src_duration, audioStat.getDuration())
+
+    # check dst audio streams
+    dst_inputFile = av.InputFile(outputFileName)
+    dst_audioProperties = dst_inputFile.getProperties().getAudioProperties()
+    assert_equals(1, len(dst_audioProperties))
+    assert_equals(2, dst_audioProperties[0].getNbChannels())
+
+def testMuxAudioChannelsFromDifferentFormatInputs_51():
+    """
+    Mux audio channels from different formats files, and generate one audio stereo stream
+    """
+    # inputs
+    inputFileName1 = os.environ['AVTRANSCODER_TEST_AUDIO_MOV_FILE']
+    inputFileName2 = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    assert_not_equals(inputFileName1, inputFileName2)
+
+    inputs = av.InputStreamDescVector()
+    inputs.append(av.InputStreamDesc(inputFileName1, 1, 1))
+    inputs.append(av.InputStreamDesc(inputFileName1, 1, 0))
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 2))
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 5))
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 1))
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 3))
+
+    # output
+    outputFileName = "testMuxAudioChannelsFromDifferentFormatInputs_51.wav"
+    ouputFile = av.OutputFile(outputFileName)
+
+    transcoder = av.Transcoder(ouputFile)
+    transcoder.addStream(inputs, "wave24b48k5_1")
+
+    progress = av.ConsoleProgress()
+    processStat = transcoder.process( progress )
+
+    # check process stat returned
+    audioStat = processStat.getAudioStat(0)
+
+    inputFile1 = av.InputFile(inputFileName1)
+    inputFile2 = av.InputFile(inputFileName2)
+
+    src_audioStream1 = inputFile1.getProperties().getAudioProperties()[0]
+    src_audioStream2 = inputFile2.getProperties().getAudioProperties()[0]
+
+    min_src_duration = min(src_audioStream1.getDuration(), src_audioStream2.getDuration())
+
+    assert_equals(min_src_duration, audioStat.getDuration())
+
+    # check dst audio streams
+    dst_inputFile = av.InputFile(outputFileName)
+    dst_audioProperties = dst_inputFile.getProperties().getAudioProperties()
+    assert_equals(1, len(dst_audioProperties))
+    assert_equals(6, dst_audioProperties[0].getNbChannels())


### PR DESCRIPTION
In order to mux audio channels, AvTranscoder uses the [amerge](https://ffmpeg.org/ffmpeg-filters.html#amerge-1) filter.
If, as inputs of the filter graph containing this _amerge_ filter, we put frames with different sizes, the resulting frame size seems to be the minimum of the input frame size. This means that one or more output channels can have cut frames, changing the reading speed and generating clicks into the final audio stream.

Using the internal filter buffer, the output frame is ensured not to lose audio samples, solving the problem of speed and clicks.
However, the filter internal buffer is quiet limited and quickly overflowed, making the process crashing before the end of the program. So, using custom frame buffers before the filter graph inputs fixes this other problem.