### PR TITLE
Muxing silent audio channels

### DIFF
--- a/src/AvTranscoder/transcoder/InputStreamDesc.hpp
+++ b/src/AvTranscoder/transcoder/InputStreamDesc.hpp
@@ -63,7 +63,7 @@ struct InputStreamDesc
     bool demultiplexing() const { return !_channelIndexArray.empty(); }
 
 public:
-    std::string _filename;                  ///< Source file path.
+    std::string _filename;                  ///< Source file path. If empty, a generator is used as source.
     size_t _streamIndex;                    ///< Source stream to extract.
     std::vector<size_t> _channelIndexArray; ///< List of source channels to extract from the stream
 };

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -147,12 +147,22 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
     size_t nbOutputChannels = 0;
     for(size_t index = 0; index < inputStreams.size(); ++index)
     {
-        addDecoder(_inputStreamDesc.at(index), *_inputStreams.at(index));
-        nbOutputChannels += _inputStreamDesc.at(index)._channelIndexArray.size();
+        if(_inputStreams.at(index) != NULL)
+        {
+            LOG_INFO("add decoder for input stream " << index);
+            addDecoder(_inputStreamDesc.at(index), *_inputStreams.at(index));
+            nbOutputChannels += _inputStreamDesc.at(index)._channelIndexArray.size();
+        }
+        else
+        {
+            LOG_INFO("add generator for empty input " << index);
+            addGenerator(_inputStreamDesc.at(index), profile);
+        }
     }
 
-    IInputStream& inputStream = *_inputStreams.at(0);
-    const InputStreamDesc& inputStreamDesc = inputStreamsDesc.at(0);
+    const size_t firstInputStreamIndex = getFirstInputStreamIndex();
+    IInputStream& inputStream = *_inputStreams.at(firstInputStreamIndex);
+    const InputStreamDesc& inputStreamDesc = inputStreamsDesc.at(firstInputStreamIndex);
 
     // create a transcode case
     switch(inputStream.getProperties().getStreamType())
@@ -229,6 +239,16 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
     setOffset(offset);
 }
 
+size_t StreamTranscoder::getFirstInputStreamIndex()
+{
+    for(size_t index = 0; index < _inputStreams.size(); ++index)
+    {
+        if(_inputStreams.at(index) != NULL)
+            return index;
+    }
+    throw std::runtime_error("Cannot handle only null input streams");
+}
+
 void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInputStream& inputStream)
 {
     // create a transcode case
@@ -275,6 +295,53 @@ void StreamTranscoder::addDecoder(const InputStreamDesc& inputStreamDesc, IInput
             throw std::runtime_error("Unupported stream type");
             break;
         }
+    }
+}
+
+void StreamTranscoder::addGenerator(const InputStreamDesc& inputStreamDesc, const ProfileLoader::Profile& profile)
+{
+    // create a transcode case
+    if(profile.find(constants::avProfileType)->second == constants::avProfileTypeVideo)
+    {
+        VideoCodec inputVideoCodec(eCodecTypeEncoder, profile.find(constants::avProfileCodec)->second);
+        VideoFrameDesc inputFrameDesc(profile);
+        inputVideoCodec.setImageParameters(inputFrameDesc);
+
+        // generator decoder
+        VideoGenerator* generator = new VideoGenerator(inputFrameDesc);
+        _generators.push_back(generator);
+        _currentDecoder = generator;
+
+        // buffers to process
+        VideoFrameDesc outputFrameDesc = inputFrameDesc;
+        outputFrameDesc.setParameters(profile);
+        _decodedData.push_back(new VideoFrame(inputFrameDesc));
+
+        // no decoder for this input
+        _inputDecoders.push_back(NULL);
+
+    }
+    else if(profile.find(constants::avProfileType)->second == constants::avProfileTypeAudio)
+    {
+        // corresponding input codec
+        AudioCodec inputAudioCodec(eCodecTypeEncoder, profile.find(constants::avProfileCodec)->second);
+        AudioFrameDesc inputFrameDesc(profile);
+        inputFrameDesc._nbChannels = 1;
+        inputAudioCodec.setAudioParameters(inputFrameDesc);
+
+        // generator decoder
+        AudioGenerator* generator = new AudioGenerator(inputFrameDesc);
+        _generators.push_back(generator);
+        _currentDecoder = generator;
+        // buffers to get the decoded data
+        _decodedData.push_back(new AudioFrame(inputFrameDesc));
+
+        // no decoder for this input
+        _inputDecoders.push_back(NULL);
+    }
+    else
+    {
+        throw std::runtime_error("unupported stream type");
     }
 }
 
@@ -375,7 +442,8 @@ StreamTranscoder::~StreamTranscoder()
 
     for(std::vector<IDecoder*>::iterator it = _inputDecoders.begin(); it != _inputDecoders.end(); ++it)
     {
-        delete(*it);
+        if(*it != NULL)
+            delete(*it);
     }
     for(std::vector<IDecoder*>::iterator it = _generators.begin(); it != _generators.end(); ++it)
     {
@@ -548,9 +616,10 @@ bool StreamTranscoder::processTranscode()
     }
 
     // check the next data buffers in case of audio frames
-    if(_decodedData.at(0)->isAudioFrame())
+    const size_t firstInputStreamIndex = getFirstInputStreamIndex();
+    if(_decodedData.at(firstInputStreamIndex)->isAudioFrame())
     {
-        const int nbInputSamplesPerChannel = _decodedData.at(0)->getAVFrame().nb_samples;
+        const int nbInputSamplesPerChannel = _decodedData.at(firstInputStreamIndex)->getAVFrame().nb_samples;
 
         // Reallocate output frame
         if(nbInputSamplesPerChannel > _filteredData->getAVFrame().nb_samples)
@@ -670,7 +739,11 @@ float StreamTranscoder::getDuration() const
         float minStreamDuration = -1;
         for(size_t index = 0; index < _inputStreams.size(); ++index)
         {
-            const StreamProperties& streamProperties = _inputStreams.at(index)->getProperties();
+            IInputStream* inputStream = _inputStreams.at(index);
+            if(inputStream == NULL)
+                continue;
+
+            const StreamProperties& streamProperties = inputStream->getProperties();
             if(minStreamDuration == -1 || streamProperties.getDuration() < minStreamDuration)
                 minStreamDuration = streamProperties.getDuration();
         }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -604,7 +604,8 @@ bool StreamTranscoder::processTranscode()
     std::vector<bool> decodingStatus(_generators.size(), true);
     for(size_t index = 0; index < _generators.size(); ++index)
     {
-        if(getProcessCase() == eProcessCaseTranscode)
+        EProcessCase processCase = getProcessCase(index);
+        if(processCase == eProcessCaseTranscode)
             _currentDecoder = _inputDecoders.at(index);
         else
             _currentDecoder = _generators.at(index);
@@ -795,13 +796,30 @@ void StreamTranscoder::setOffset(const float offset)
     }
 }
 
-StreamTranscoder::EProcessCase StreamTranscoder::getProcessCase() const
+StreamTranscoder::EProcessCase StreamTranscoder::getProcessCase(const size_t decoderIndex) const
 {
-    if(! _inputStreams.empty() && ! _inputDecoders.empty() && std::find(_inputDecoders.begin(), _inputDecoders.end(), _currentDecoder) != _inputDecoders.end() )
-        return eProcessCaseTranscode;
-    else if(! _inputStreams.empty() && _inputDecoders.empty() && !_currentDecoder)
-        return eProcessCaseRewrap;
+    if(_inputStreamDesc.size() <= 1)
+    {
+        if(! _inputStreams.empty() && ! _inputDecoders.empty() && std::find(_inputDecoders.begin(), _inputDecoders.end(), _currentDecoder) != _inputDecoders.end() )
+            return eProcessCaseTranscode;
+        else if(! _inputStreams.empty() && _inputDecoders.empty() && !_currentDecoder)
+            return eProcessCaseRewrap;
+        else
+            return eProcessCaseGenerator;
+    }
     else
+    {
+        if(! _inputStreams.empty() && _currentDecoder != NULL)
+        {
+            if( _inputStreams.at(decoderIndex) != NULL)
+                return eProcessCaseTranscode;
+            return eProcessCaseGenerator;
+        }
+        else if(! _inputStreams.empty() && _inputDecoders.empty() && !_currentDecoder)
+        {
+            return eProcessCaseRewrap;
+        }
         return eProcessCaseGenerator;
+    }
 }
 }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -165,6 +165,9 @@ StreamTranscoder::StreamTranscoder(const std::vector<InputStreamDesc>& inputStre
         }
     }
 
+    if(_firstInputStreamIndex == std::numeric_limits<size_t>::max())
+        throw std::runtime_error("Cannot handle empty only input streams");
+
     IInputStream& inputStream = *_inputStreams.at(_firstInputStreamIndex);
     const InputStreamDesc& inputStreamDesc = inputStreamsDesc.at(_firstInputStreamIndex);
 

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -115,7 +115,7 @@ public:
         eProcessCaseRewrap,
         eProcessCaseGenerator
     };
-    EProcessCase getProcessCase() const;
+    EProcessCase getProcessCase(const size_t decoderIndex = 0) const;
     //@}
 
 private:

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -125,9 +125,12 @@ private:
      * @param inputStream
      */
     void addDecoder(const InputStreamDesc& inputStreamDesc, IInputStream& inputStream);
+    void addGenerator(const InputStreamDesc& inputStreamDesc, const ProfileLoader::Profile& profile);
 
     bool processRewrap();
     bool processTranscode();
+
+    size_t getFirstInputStreamIndex();
 
 private:
     std::vector<InputStreamDesc> _inputStreamDesc; ///< Description of the data to extract from the input stream.

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -130,8 +130,6 @@ private:
     bool processRewrap();
     bool processTranscode();
 
-    size_t getFirstInputStreamIndex();
-
 private:
     std::vector<InputStreamDesc> _inputStreamDesc; ///< Description of the data to extract from the input stream.
     std::vector<IInputStream*> _inputStreams;   ///< List of input stream to read next packet (has link, no ownership)
@@ -149,6 +147,8 @@ private:
     ITransform* _transform; ///< Video or audio transform (has ownership)
 
     FilterGraph* _filterGraph; ///< Filter graph (has ownership)
+
+    size_t _firstInputStreamIndex; ///< Index of the first non-null input stream.
 
     float _offset; ///< Offset, in seconds, at the beginning of the StreamTranscoder.
 

--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -260,6 +260,12 @@ void Transcoder::addTranscodeStream(const std::vector<InputStreamDesc>& inputStr
     AVMediaType commonStreamType = AVMEDIA_TYPE_UNKNOWN;
     for(std::vector<InputStreamDesc>::const_iterator it = inputStreamDescArray.begin(); it != inputStreamDescArray.end(); ++it)
     {
+        if(it->_filename.empty())
+        {
+            inputStreams.push_back(NULL);
+            continue;
+        }
+
         InputFile* referenceFile = addInputFile(it->_filename, it->_streamIndex, offset);
         inputStreams.push_back(&referenceFile->getStream(it->_streamIndex));
 
@@ -329,7 +335,16 @@ ProfileLoader::Profile Transcoder::getProfileFromInputs(const std::vector<InputS
     assert(inputStreamDescArray.size() >= 1);
 
     // Get properties from the first input
-    const InputStreamDesc& inputStreamDesc = inputStreamDescArray.at(0);
+    size_t nonEmptyFileName = 0;
+    for(size_t i = 0; i < inputStreamDescArray.size(); ++i)
+    {
+        if(!inputStreamDescArray.at(i)._filename.empty())
+        {
+            nonEmptyFileName = i;
+            break;
+        }
+    }
+    const InputStreamDesc& inputStreamDesc = inputStreamDescArray.at(nonEmptyFileName);
     InputFile inputFile(inputStreamDesc._filename);
 
     const StreamProperties* streamProperties = &inputFile.getProperties().getStreamPropertiesWithIndex(inputStreamDesc._streamIndex);
@@ -519,7 +534,19 @@ void Transcoder::fillProcessStat(ProcessStat& processStat)
             LOG_WARN("Cannot process statistics of generated stream.")
             continue;
         }
-        const IInputStream* inputStream = _streamTranscoders.at(streamIndex)->getInputStreams().at(0);
+
+        size_t nonNullInputStreamIndex = 0;
+        std::vector<IInputStream*> inputStreams = _streamTranscoders.at(streamIndex)->getInputStreams();
+        for(size_t i = 0; i < inputStreams.size(); ++i)
+        {
+            if(inputStreams.at(i) != NULL)
+            {
+                nonNullInputStreamIndex = i;
+                break;
+            }
+        }
+
+        const IInputStream* inputStream = inputStreams.at(nonNullInputStreamIndex);
         const AVMediaType mediaType = inputStream->getProperties().getStreamType();
         switch(mediaType)
         {

--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -335,7 +335,7 @@ ProfileLoader::Profile Transcoder::getProfileFromInputs(const std::vector<InputS
     assert(inputStreamDescArray.size() >= 1);
 
     // Get properties from the first input
-    size_t nonEmptyFileName = 0;
+    size_t nonEmptyFileName = -1;
     for(size_t i = 0; i < inputStreamDescArray.size(); ++i)
     {
         if(!inputStreamDescArray.at(i)._filename.empty())
@@ -344,6 +344,9 @@ ProfileLoader::Profile Transcoder::getProfileFromInputs(const std::vector<InputS
             break;
         }
     }
+    if(nonEmptyFileName == -1)
+        throw std::runtime_error("Cannot handle only empty streams as input");
+
     const InputStreamDesc& inputStreamDesc = inputStreamDescArray.at(nonEmptyFileName);
     InputFile inputFile(inputStreamDesc._filename);
 

--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -335,7 +335,7 @@ ProfileLoader::Profile Transcoder::getProfileFromInputs(const std::vector<InputS
     assert(inputStreamDescArray.size() >= 1);
 
     // Get properties from the first input
-    size_t nonEmptyFileName = -1;
+    size_t nonEmptyFileName = std::numeric_limits<size_t>::max();
     for(size_t i = 0; i < inputStreamDescArray.size(); ++i)
     {
         if(!inputStreamDescArray.at(i)._filename.empty())
@@ -344,8 +344,8 @@ ProfileLoader::Profile Transcoder::getProfileFromInputs(const std::vector<InputS
             break;
         }
     }
-    if(nonEmptyFileName == -1)
-        throw std::runtime_error("Cannot handle only empty streams as input");
+    if(nonEmptyFileName == std::numeric_limits<size_t>::max())
+        throw std::runtime_error("Cannot get profile from empty input streams");
 
     const InputStreamDesc& inputStreamDesc = inputStreamDescArray.at(nonEmptyFileName);
     InputFile inputFile(inputStreamDesc._filename);

--- a/test/pyTest/testMuxAudioChannels.py
+++ b/test/pyTest/testMuxAudioChannels.py
@@ -60,7 +60,7 @@ def testMuxAudioChannelsFromDifferentFormatInputs_20():
 
 def testMuxAudioChannelsFromDifferentFormatInputs_51():
     """
-    Mux audio channels from different formats files, and generate one audio stereo stream
+    Mux audio channels from different formats files, and generate one audio 5.1 stream
     """
     # inputs
     inputFileName1 = os.environ['AVTRANSCODER_TEST_AUDIO_MOV_FILE']
@@ -107,3 +107,155 @@ def testMuxAudioChannelsFromDifferentFormatInputs_51():
     dst_audioProperties = dst_inputFile.getProperties().getAudioProperties()
     assert_equals(1, len(dst_audioProperties))
     assert_equals(6, dst_audioProperties[0].getNbChannels())
+
+
+def testMuxAudioChannelsWithSilence_20():
+    """
+    Mux audio channels with generated silence, and generate one audio stereo stream
+    """
+    # input
+    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+
+    inputs = av.InputStreamDescVector()
+    inputs.append(av.InputStreamDesc(inputFileName, 0, 0))
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+
+    # output
+    outputFileName = "testMuxAudioChannelsWithSilence_20.wav"
+    ouputFile = av.OutputFile(outputFileName)
+
+    transcoder = av.Transcoder(ouputFile)
+    transcoder.addStream(inputs, "wave24b48kstereo")
+
+    progress = av.ConsoleProgress()
+    processStat = transcoder.process( progress )
+
+    # check process stat returned
+    audioStat = processStat.getAudioStat(0)
+
+    inputFile = av.InputFile(inputFileName)
+
+    src_audioStream = inputFile.getProperties().getAudioProperties()[0]
+
+    assert_equals(src_audioStream.getDuration(), audioStat.getDuration())
+
+    # check dst file properties
+    dst_inputFile = av.InputFile(outputFileName)
+    dst_fileProperties = dst_inputFile.getProperties()
+    assert_equals(src_audioStream.getDuration(), dst_fileProperties.getDuration())
+
+    # check dst audio streams
+    dst_audioProperties = dst_fileProperties.getAudioProperties()
+    assert_equals(1, len(dst_audioProperties))
+    assert_equals(2, dst_audioProperties[0].getNbChannels())
+
+def testMuxAudioChannelsWithSilenceProfileFromInput_20():
+    """
+    Mux audio channels with generated silence, and generate one audio stereo stream
+    """
+    # input
+    inputFileName = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+
+    inputs = av.InputStreamDescVector()
+    inputs.append(av.InputStreamDesc(inputFileName, 0, 0))
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+
+    # output
+    outputFileName = "testMuxAudioChannelsWithSilenceNoProfile_20.wav"
+    ouputFile = av.OutputFile(outputFileName)
+
+    transcoder = av.Transcoder(ouputFile)
+    transcoder.addStream(inputs)
+
+    progress = av.ConsoleProgress()
+    processStat = transcoder.process( progress )
+
+    # check process stat returned
+    audioStat = processStat.getAudioStat(0)
+
+    inputFile = av.InputFile(inputFileName)
+
+    src_audioStream = inputFile.getProperties().getAudioProperties()[0]
+
+    assert_equals(src_audioStream.getDuration(), audioStat.getDuration())
+
+    # check dst file properties
+    dst_inputFile = av.InputFile(outputFileName)
+    dst_fileProperties = dst_inputFile.getProperties()
+    assert_equals(src_audioStream.getDuration(), dst_fileProperties.getDuration())
+
+    # check dst audio streams
+    dst_audioProperties = dst_fileProperties.getAudioProperties()
+    assert_equals(1, len(dst_audioProperties))
+    assert_equals(2, dst_audioProperties[0].getNbChannels())
+
+def testMuxAudioChannelsWithSilenceProfileFromInput_51():
+    """
+    Mux audio channels with generated silence, and generate one audio 5.1 stream
+    """
+    # inputs
+    inputFileName1 = os.environ['AVTRANSCODER_TEST_AUDIO_MOV_FILE']
+    inputFileName2 = os.environ['AVTRANSCODER_TEST_AUDIO_WAVE_FILE']
+    assert_not_equals(inputFileName1, inputFileName2)
+
+    inputs = av.InputStreamDescVector()
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+    inputs.append(av.InputStreamDesc(inputFileName1, 1, 0))
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 2))
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+    inputs.append(av.InputStreamDesc(inputFileName2, 0, 1))
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+
+    # output
+    outputFileName = "testMuxAudioChannelsWithSilenceProfileFromInput_51.wav"
+    ouputFile = av.OutputFile(outputFileName)
+
+    transcoder = av.Transcoder(ouputFile)
+    transcoder.addStream(inputs)
+
+    progress = av.ConsoleProgress()
+    processStat = transcoder.process( progress )
+
+    # check process stat returned
+    audioStat = processStat.getAudioStat(0)
+
+    inputFile1 = av.InputFile(inputFileName1)
+    inputFile2 = av.InputFile(inputFileName2)
+
+    src_audioStream1 = inputFile1.getProperties().getAudioProperties()[0]
+    src_audioStream2 = inputFile2.getProperties().getAudioProperties()[0]
+
+    min_src_duration = min(src_audioStream1.getDuration(), src_audioStream2.getDuration())
+
+    assert_equals(min_src_duration, audioStat.getDuration())
+
+    # check dst file properties
+    dst_inputFile = av.InputFile(outputFileName)
+    dst_fileProperties = dst_inputFile.getProperties()
+    assert_equals(min_src_duration, dst_fileProperties.getDuration())
+
+    # check dst audio streams
+    dst_audioProperties = dst_inputFile.getProperties().getAudioProperties()
+    assert_equals(1, len(dst_audioProperties))
+    assert_equals(6, dst_audioProperties[0].getNbChannels())
+
+@raises(RuntimeError)
+def testMuxAudioChannelsWithSilenceOnly_20():
+    """
+    Mux audio channels with generated silence, and generate one audio stereo stream
+    """
+    # input
+    inputs = av.InputStreamDescVector()
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+    inputs.append(av.InputStreamDesc("", 0, 0)) # empty filename to generate silence
+
+    # output
+    outputFileName = "testMuxAudioChannelsWithSilenceOnly_20.wav"
+    ouputFile = av.OutputFile(outputFileName)
+
+    transcoder = av.Transcoder(ouputFile)
+    transcoder.addStream(inputs, "wave24b48kstereo")
+
+    progress = av.ConsoleProgress()
+    processStat = transcoder.process( progress )
+


### PR DESCRIPTION
The idea of this PR is to enable muxing of generated streams into a multichannel output stream.
To indicate we want to generate such a channel, we can now create one or more _InputStreamDesc_ with empty filename, and add it to the input sources of a _Transcoder_. A generator will be used as channel source.
However, we cannot generate an output stream will only generated channels with this method, since we can use _Transcoder::addGenerateStream()_ method with the corresponding output profile.
But for instance, we can now create a 5.1 audio stream with a silent LFE channel.