### PR TITLE
Fix: stop the process even if the wrapper expects more data

### DIFF
--- a/src/AvTranscoder/file/OutputFile.cpp
+++ b/src/AvTranscoder/file/OutputFile.cpp
@@ -188,7 +188,7 @@ bool OutputFile::beginWrap()
 IOutputStream::EWrappingStatus OutputFile::wrap(const CodedData& data, const size_t streamIndex)
 {
     if(!data.getSize())
-        return IOutputStream::eWrappingSuccess;
+        return IOutputStream::eWrappingSkip;
 
     LOG_DEBUG("Wrap on stream " << streamIndex << " (" << data.getSize() << " bytes for frame "
                                 << _frameCount.at(streamIndex) << ")")

--- a/src/AvTranscoder/stream/IOutputStream.hpp
+++ b/src/AvTranscoder/stream/IOutputStream.hpp
@@ -16,9 +16,10 @@ public:
      **/
     enum EWrappingStatus
     {
-        eWrappingSuccess = 0,
-        eWrappingWaitingForData,
-        eWrappingError,
+        eWrappingSuccess = 0,    ///< The wrapping succeeded
+        eWrappingWaitingForData, ///< The wrapper expects more data to complete the writing process
+        eWrappingSkip,           ///< The wrapper receives empty data, so nothing is written
+        eWrappingError,          ///< An error occurred during the wrapping process
     };
 
     virtual ~IOutputStream(){};

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -69,7 +69,7 @@ public:
      * @brief process a single frame for the current stream
      * @return the process status result
      */
-    bool processFrame();
+    IOutputStream::EWrappingStatus processFrame();
 
     //@{
     // Switch current decoder.
@@ -139,8 +139,8 @@ private:
     void addDecoder(const InputStreamDesc& inputStreamDesc, IInputStream& inputStream);
     void addGenerator(const InputStreamDesc& inputStreamDesc, const ProfileLoader::Profile& profile);
 
-    bool processRewrap();
-    bool processTranscode();
+    IOutputStream::EWrappingStatus processRewrap();
+    IOutputStream::EWrappingStatus processTranscode();
 
 private:
     std::vector<InputStreamDesc> _inputStreamDesc; ///< Description of the data to extract from the input stream.

--- a/src/AvTranscoder/transcoder/Transcoder.hpp
+++ b/src/AvTranscoder/transcoder/Transcoder.hpp
@@ -95,9 +95,11 @@ public:
 
     /**
      * @brief Process the next frame of all streams.
+     * @param progress: choose a progress, or create your own in C++ or in bindings by inherit IProgress class.
      * @return if a frame was processed or not.
      */
-    bool processFrame();
+    bool processFrame(IProgress& progress);
+    bool processFrame(); ///< Call processFrame with no display of progression
 
     /**
      * @brief Process all the streams, and ended the process depending on the transcode politic.
@@ -191,6 +193,19 @@ private:
     void manageSwitchToGenerator();
 
     /**
+     * @brief Process the next frame of the specified stream.
+     * @return whether a frame was processed or not.
+     */
+    bool processFrame(IProgress& progress, const size_t& streamIndex);
+
+    /**
+     * @brief Check whether the process is canceled or not, and whether the process reached the ending condition.
+     * @note The progress is updated in this function.
+     * @return whether the process must continue or stop.
+     */
+    bool continueProcess(IProgress& progress);
+
+    /**
      * @brief Fill the given ProcessStat to summarize the process.
      */
     void fillProcessStat(ProcessStat& processStat);
@@ -205,10 +220,11 @@ private:
     ProfileLoader _profileLoader; ///< Objet to get existing profiles, and add new ones for the Transcoder.
 
     EProcessMethod _eProcessMethod; ///< Processing policy
-    size_t
-        _mainStreamIndex;  ///< Index of stream used to stop the process.
-    float _outputDuration; ///< Duration of output media used to stop the process of transcode in case of
-    /// eProcessMethodBasedOnDuration.
+
+    size_t _mainStreamIndex;  ///< Index of stream used to stop the process.
+    size_t _processedFrames;  ///< Counter for the number of processed frames.
+
+    float _outputDuration; ///< Duration of output media used to stop the process of transcode in case of eProcessMethodBasedOnDuration.
 };
 }
 


### PR DESCRIPTION
This PR fixes the case when the wrapper expects some more data to complete the wrapping, while the process should stop since the ending condition is reached. This case happens when the process is ending by a generated stream (black or silence).